### PR TITLE
v0: fname fetcher

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ malachite-node = { path = "../malachite/code/crates/node"}
 malachite-metrics = { path = "../malachite/code/crates/metrics"}
 
 tracing = "0.1.40"
+thiserror = "1.0.66"
+reqwest = { version = "0.12.9", features = ["json"] }
 
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,14 +15,14 @@ parking_lot = "0.12.1"
 clap = { version = "4.3.0", features = ["derive"] }
 libp2p = { version = "0.54.1", features = ["tokio", "gossipsub", "mdns", "noise", "macros", "tcp", "yamux", "quic"] }
 async-trait = "0.1.68"
-tracing-subscriber = {  version = "0.3.18", features = ["env-filter", "fmt"] }
+tracing-subscriber = {  version = "0.3.18", features = ["env-filter", "fmt", "json"] }
 hex = "0.4.3"
-ractor             = "0.11.2"
-malachite-consensus = { path = "../malachite/code/crates/consensus"}
-malachite-common = { path = "../malachite/code/crates/common"}
-malachite-config = { path = "../malachite/code/crates/config"}
-malachite-node = { path = "../malachite/code/crates/node"}
-malachite-metrics = { path = "../malachite/code/crates/metrics"}
+ractor = "0.11.2"
+malachite-consensus = { path = "../malachite/code/crates/consensus" }
+malachite-common = { path = "../malachite/code/crates/common" }
+malachite-config = { path = "../malachite/code/crates/config" }
+malachite-node = { path = "../malachite/code/crates/node" }
+malachite-metrics = { path = "../malachite/code/crates/metrics" }
 
 tracing = "0.1.40"
 thiserror = "1.0.66"

--- a/src/connectors/fname/mod.rs
+++ b/src/connectors/fname/mod.rs
@@ -1,0 +1,107 @@
+use tokio::time::{sleep, Duration};
+use serde::Deserialize;
+use thiserror::Error;
+
+
+// TODO: use actual logger
+
+
+#[derive(Deserialize, Debug)]
+struct TransfersData {
+    transfers: Vec<Transfer>,
+}
+
+#[derive(Deserialize, Debug)]
+struct Transfer {
+    id: u64,
+    timestamp: u64,
+    username: String,
+    owner: String,
+    from: u64,
+    to: u64,
+    user_signature: String,
+    server_signature: String,
+}
+
+
+#[derive(Error, Debug)]
+pub enum FnamesError {
+    #[error("non-sequential IDs found")]
+    NonSequentialIds,
+}
+
+#[derive(Error, Debug)]
+enum FetchError {
+    #[error("non-sequential IDs found")]
+    NonSequentialIds,
+
+    #[error("no new IDs found")]
+    NoNewIDs,
+
+    #[error(transparent)]
+    Reqwest(#[from] reqwest::Error),
+}
+
+
+pub struct Fetcher {
+    count: u64,
+    transfers: Vec<Transfer>,
+}
+
+impl Fetcher {
+    pub fn new(initial_count: u64) -> Self {
+        Fetcher {
+            count: initial_count,
+            transfers: vec![],
+        }
+    }
+
+    async fn fetch(&mut self) -> Result<u64, FetchError> {
+        let mut count = self.count;
+
+        loop {
+            let url = format!("https://fnames.farcaster.xyz/transfers?from_id={}", count);
+            println!("fname: fetching url: {}", url);
+
+            let response = reqwest::get(&url)
+                .await?
+                .json::<TransfersData>()
+                .await?;
+
+            let transfers_count = response.transfers.len();
+
+            if transfers_count == 0 {
+                return Ok(count);
+            }
+
+            println!("fname: found {} new transfers", transfers_count);
+
+            for t in response.transfers {
+                if t.id <= count {
+                    return Err(FetchError::NonSequentialIds);
+                }
+                count = t.id;
+                self.transfers.push(t); // Just store these for now, we'll use them later
+            }
+        }
+    }
+
+    pub async fn run(&mut self) -> FnamesError {
+        loop {
+            match self.fetch().await {
+                Ok(new_count) => self.count = new_count,
+                Err(e) => match e {
+                    FetchError::NonSequentialIds => {
+                        return FnamesError::NonSequentialIds;
+                    }
+                    FetchError::Reqwest(request_error) => {
+                        println!("fname: reqwest error fetching: {}", request_error);
+                    }
+                    FetchError::NoNewIDs => {} // just sleep and retry
+                },
+            }
+
+            sleep(Duration::from_secs(5)).await;
+        }
+    }
+}

--- a/src/connectors/mod.rs
+++ b/src/connectors/mod.rs
@@ -1,0 +1,1 @@
+pub mod fname;

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
 
     tracing_subscriber::fmt()
-        .json()
         .with_env_filter(env_filter)
         .init();
 
@@ -76,12 +75,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     });
 
     // TODO: config to enable/disable running this fetcher
-    // TODO: add start_from as a parameter
+    // TODO: add start_from (and possibly stop_at) as parameter(s)
     let mut fetcher = Fetcher::new(685400u64);
 
     tokio::spawn(async move {
-        let resp = fetcher.run().await;
-        println!("fetch error: {:?}", resp);
+        fetcher.run().await;
     });
 
     let registry = SharedRegistry::global();

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,9 +49,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("SnapchainService (ID: {}) listening on {}", args.id, addr);
 
-    let _ = tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::from_default_env())
-        .try_init();
+    let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+
+    tracing_subscriber::fmt()
+        .json()
+        .with_env_filter(env_filter)
+        .init();
 
     let keypair = Keypair::generate();
 


### PR DESCRIPTION
Initial version of code to fetch fnames and store them in memory (for now).

This also uses the `tracing` logger and enables json output.

When running, you can see lines like:

```
{"timestamp":"2024-11-02T01:22:35.272756Z","level":"DEBUG","fields":{"message":"fetching transfers","url":"https://fnames.farcaster.xyz/transfers?from_id=685400"},"target":"snapchain::connectors::fname"}
{"timestamp":"2024-11-02T01:22:35.751982Z","level":"INFO","fields":{"message":"found new transfers","count":100,"position":685400},"target":"snapchain::connectors::fname"}
{"timestamp":"2024-11-02T01:22:35.752016Z","level":"DEBUG","fields":{"message":"fetching transfers","url":"https://fnames.farcaster.xyz/transfers?from_id=685500"},"target":"snapchain::connectors::fname"}
{"timestamp":"2024-11-02T01:22:36.281028Z","level":"INFO","fields":{"message":"found new transfers","count":100,"position":685500},"target":"snapchain::connectors::fname"}
{"timestamp":"2024-11-02T01:22:36.281093Z","level":"DEBUG","fields":{"message":"fetching transfers","url":"https://fnames.farcaster.xyz/transfers?from_id=685600"},"target":"snapchain::connectors::fname"}
{"timestamp":"2024-11-02T01:22:36.789052Z","level":"INFO","fields":{"message":"found new transfers","count":79,"position":685600},"target":"snapchain::connectors::fname"}
{"timestamp":"2024-11-02T01:22:36.789202Z","level":"DEBUG","fields":{"message":"fetching transfers","url":"https://fnames.farcaster.xyz/transfers?from_id=685679"},"target":"snapchain::connectors::fname"}
```

Currently I've hardcoded the start point at ID 685400 so that we exercise the code but don't flood the server.

The logic is: fetch without delay as long as non-error, non-empty responses come in. In the case of errors or empty responses we'll sleep for 5s.

The fetcher may exit with an error if it detects a non-incrementing sequence number.

In a follow on version I'll:
- add an enable/disable toggle
- add a config value to set the start ID.