### PR TITLE
use lib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,7 @@ default-run = "snapchain"
 
 [lib]
 name = "snapchain"
-path = "src/main.rs"
-
-[[bin]]
-name = "submit-message"
-path = "src/bin/submit_message.rs"
+path = "src/lib.rs"
 
 [dependencies]
 tokio = { version = "1.40.0", features = ["full"] }

--- a/src/consensus/consensus.rs
+++ b/src/consensus/consensus.rs
@@ -20,7 +20,7 @@ use crate::consensus::timers::{TimeoutElapsed, TimerScheduler};
 use crate::core::types::proto::{BlockProposal, ShardHash};
 use crate::core::types::{Address, Height, ShardId, SnapchainContext, SnapchainShard, SnapchainValidator, SnapchainValidatorContext, SnapchainValidatorSet};
 use crate::network::gossip::GossipEvent;
-use crate::proto::{Block, BlockHeader, Height as ProtoHeight};
+use crate::core::types::proto::{Block, BlockHeader, Height as ProtoHeight};
 pub use malachite_consensus::Params as ConsensusParams;
 pub use malachite_consensus::State as ConsensusState;
 use prost::Message;
@@ -31,6 +31,11 @@ pub type ConsensusRef<Ctx> = ActorRef<ConsensusMsg<Ctx>>;
 
 pub type Decision<Ctx> = (<Ctx as Context>::Height, Round, <Ctx as Context>::Value);
 pub type TxDecision<Ctx> = mpsc::Sender<Decision<Ctx>>;
+
+pub enum SystemMessage {
+    Consensus(ConsensusMsg<SnapchainValidatorContext>),
+}
+
 type Timers<Ctx> = TimerScheduler<Timeout, ConsensusMsg<Ctx>>;
 
 impl<Ctx: Context + SnapchainContext> From<TimeoutElapsed<Timeout>> for ConsensusMsg<Ctx> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,8 @@
-mod cfg;
-mod connectors;
+pub mod cfg;
+pub mod connectors;
+pub mod consensus;
+pub mod core;
+pub mod network;
 
 mod tests;
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ use tonic::transport::Server;
 use tracing::{error, info};
 use tracing_subscriber::EnvFilter;
 
-use crate::consensus::consensus::{Consensus, ConsensusMsg, ConsensusParams};
+use crate::consensus::consensus::{Consensus, ConsensusMsg, ConsensusParams, SystemMessage};
 use crate::core::types::{
     proto, Address, Height, ShardId, SnapchainShard, SnapchainValidator, SnapchainValidatorContext,
     SnapchainValidatorSet,
@@ -30,10 +30,6 @@ use crate::network::gossip::GossipEvent;
 use network::gossip::SnapchainGossip;
 use network::server::rpc::snapchain_service_server::SnapchainServiceServer;
 use network::server::MySnapchainService;
-
-pub enum SystemMessage {
-    Consensus(ConsensusMsg<SnapchainValidatorContext>),
-}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {

--- a/src/network/gossip.rs
+++ b/src/network/gossip.rs
@@ -1,6 +1,5 @@
-use crate::consensus::consensus::ConsensusMsg;
+use crate::consensus::consensus::{ConsensusMsg, SystemMessage};
 use crate::core::types::{proto, Proposal, ShardId, Signature, SnapchainContext, SnapchainShard, SnapchainValidator, SnapchainValidatorContext, Vote};
-use crate::{SystemMessage};
 use futures::StreamExt;
 use libp2p::identity::ed25519::Keypair;
 use libp2p::{
@@ -15,6 +14,8 @@ use tokio::io;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::Sender;
 use tracing::{debug, info, warn};
+
+
 
 pub enum GossipEvent<Ctx: SnapchainContext> {
     BroadcastSignedVote(SignedVote<Ctx>),

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -6,6 +6,7 @@ use ractor::{Actor, ActorRef};
 use tokio::{select, time};
 use tokio::sync::mpsc;
 use tracing::debug;
+use tracing_subscriber::EnvFilter;
 use snapchain::{
     consensus::consensus::{Consensus, ConsensusMsg},
     core::types::{
@@ -76,6 +77,8 @@ impl NodeForTest {
 
 #[tokio::test]
 async fn test_basic_consensus() {
+    let _ = tracing_subscriber::fmt().with_env_filter(EnvFilter::new("info")).init();
+
     // Create validator keys
     let keypair1 = Keypair::generate();
     let keypair2 = Keypair::generate();


### PR DESCRIPTION
This is the first step in being able to import protobufs from a centralized place.

[lib]
name = "snapchain"
path = "src/lib.rs"

Pretty sure this is the convention and having src/main.rs is causing all kinds of mischief.