### PR TITLE
add rpc address to RegisterValidator

### DIFF
--- a/src/bin/setup.rs
+++ b/src/bin/setup.rs
@@ -18,10 +18,12 @@ async fn main() {
             std::fs::create_dir(format!("nodes/{id}")).expect("Failed to create node directory");
         }
         let secret_key = hex::encode(SecretKey::generate());
+        let rpc_port = 2283 + i;
 
         let config_file_content = format!(
             r#"
 id = {id}
+rpc_address=0.0.0.0:{rpc_port}
 
 [consensus]
 private_key = "{secret_key}"

--- a/src/bin/setup.rs
+++ b/src/bin/setup.rs
@@ -18,7 +18,7 @@ async fn main() {
             std::fs::create_dir(format!("nodes/{id}")).expect("Failed to create node directory");
         }
         let secret_key = hex::encode(SecretKey::generate());
-        let rpc_port = 2283 + i;
+        let rpc_port = 3383 + i;
 
         let config_file_content = format!(
             r#"

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -26,7 +26,7 @@ impl Default for Config {
             fnames: connectors::fname::Config::default(),
             onchain_events: connectors::onchain_events::Config::default(),
             consensus: consensus::consensus::Config::default(),
-            rpc_address: "0.0.0.0:2283".to_string(),
+            rpc_address: "0.0.0.0:3383".to_string(),
         }
     }
 }

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -15,6 +15,7 @@ pub struct Config {
     pub fnames: connectors::fname::Config,
     pub onchain_events: connectors::onchain_events::Config,
     pub consensus: consensus::consensus::Config,
+    pub rpc_address: String,
 }
 
 impl Default for Config {
@@ -25,6 +26,7 @@ impl Default for Config {
             fnames: connectors::fname::Config::default(),
             onchain_events: connectors::onchain_events::Config::default(),
             consensus: consensus::consensus::Config::default(),
+            rpc_address: "0.0.0.0:2283".to_string(),
         }
     }
 }

--- a/src/consensus/consensus.rs
+++ b/src/consensus/consensus.rs
@@ -805,6 +805,7 @@ impl Actor for Consensus {
         state.shard_validator.add_validator(SnapchainValidator::new(
             self.shard_id.clone(),
             self.ctx.public_key(),
+            None,
         ));
         Ok(())
     }

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -8,6 +8,7 @@ use malachite_common::{
 use prost::Message;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display};
+use std::net::IpAddr;
 use std::sync::Arc;
 use tracing::warn;
 
@@ -247,14 +248,20 @@ pub struct SnapchainValidator {
     pub shard_index: u8,
     pub address: Address,
     pub public_key: PublicKey,
+    pub rpc_address: Option<String>,
 }
 
 impl SnapchainValidator {
-    pub fn new(shard_index: SnapchainShard, public_key: PublicKey) -> Self {
+    pub fn new(
+        shard_index: SnapchainShard,
+        public_key: PublicKey,
+        rpc_address: Option<String>,
+    ) -> Self {
         Self {
             shard_index: shard_index.shard_id(),
             address: Address(public_key.to_bytes()),
             public_key,
+            rpc_address,
         }
     }
 }

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -8,7 +8,6 @@ use malachite_common::{
 use prost::Message;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display};
-use std::net::IpAddr;
 use std::sync::Arc;
 use tracing::warn;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,7 +135,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let shard = SnapchainShard::new(0); // Single shard for now
     let validator_address = Address(keypair.public().to_bytes());
-    let validator = SnapchainValidator::new(shard.clone(), keypair.public().clone());
+    let validator = SnapchainValidator::new(
+        shard.clone(),
+        keypair.public().clone(),
+        Some(app_config.rpc_address.clone()),
+    );
     let validator_set = SnapchainValidatorSet::new(vec![validator]);
 
     let consensus_params = ConsensusParams {
@@ -188,6 +192,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                         validator: Some(proto::Validator {
                             signer: keypair.public().to_bytes().to_vec(),
                             fid: 0,
+                            rpc_address: app_config.rpc_address.clone()
                         }),
                         nonce: tick_count as u64,   // Need the nonce to avoid the gossip duplicate message check
                     };

--- a/src/network/gossip.rs
+++ b/src/network/gossip.rs
@@ -154,7 +154,8 @@ impl SnapchainGossip {
                                                     warn!("Failed to decode public key from peer: {}", peer_id);
                                                     continue;
                                                 }
-                                                let validator = SnapchainValidator::new(SnapchainShard::new(0), public_key.unwrap());
+                                                let rpc_address = validator.rpc_address;
+                                                let validator = SnapchainValidator::new(SnapchainShard::new(0), public_key.unwrap(), Some(rpc_address));
                                                 let consensus_message = ConsensusMsg::RegisterValidator(validator);
                                                 let res = self.system_tx.send(SystemMessage::Consensus(consensus_message)).await;
                                                 if let Err(e) = res {

--- a/src/proto/blocks.proto
+++ b/src/proto/blocks.proto
@@ -6,6 +6,7 @@ package snapchain;
 message Validator {
   uint64 fid = 1;
   bytes signer = 2;
+  string rpc_address = 3;
 }
 
 message ValidatorSet {


### PR DESCRIPTION
We need to be able to reach peers via rpc for block sync, so add the rpc address to the broadcasted info about each validator. 