### PR TITLE
Sharded Block Production

### DIFF
--- a/src/bin/setup.rs
+++ b/src/bin/setup.rs
@@ -1,4 +1,4 @@
-use libp2p::identity::ed25519::{Keypair, SecretKey};
+use libp2p::identity::ed25519::SecretKey;
 
 #[tokio::main]
 async fn main() {
@@ -12,7 +12,6 @@ async fn main() {
 
     for i in 1..=nodes {
         let id = i;
-        let keypair = Keypair::generate();
 
         if !std::path::Path::new(format!("nodes/{id}").as_str()).exists() {
             std::fs::create_dir(format!("nodes/{id}")).expect("Failed to create node directory");

--- a/src/bin/submit-message.rs
+++ b/src/bin/submit-message.rs
@@ -1,12 +1,11 @@
 use ed25519_dalek::{SecretKey, Signer, SigningKey};
-use hex::{FromHex, ToHex};
+use hex::FromHex;
 use message::CastType::Cast;
 use message::MessageType::CastAdd;
 use message::{CastAddBody, FarcasterNetwork, MessageData};
 use prost::Message;
 use snapchain::proto::message;
 use snapchain::proto::rpc::snapchain_service_client::SnapchainServiceClient;
-use snapchain::proto::rpc::snapchain_service_server::SnapchainService;
 use std::error::Error;
 
 const FARCASTER_EPOCH: u64 = 1609459200; // January 1, 2021 UTC
@@ -37,10 +36,10 @@ async fn compose_message(
         r#type: Cast as i32,
     };
 
-    let mut msg_data = MessageData {
+    let msg_data = MessageData {
         fid,
         r#type: CastAdd as i32,
-        timestamp: timestamp,
+        timestamp,
         network: network as i32,
         body: Some(message::message_data::Body::CastAddBody(cast_add)),
     };

--- a/src/connectors/fname/mod.rs
+++ b/src/connectors/fname/mod.rs
@@ -1,8 +1,7 @@
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
 use thiserror::Error;
 use tokio::time::{sleep, Duration};
-use tracing::{debug, error, info, span, warn, Level, Span};
+use tracing::{debug, error, info, warn};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Config {

--- a/src/consensus/consensus.rs
+++ b/src/consensus/consensus.rs
@@ -191,7 +191,7 @@ impl Proposer for ShardProposer {
         &mut self,
         height: Height,
         round: Round,
-        timeout: Duration,
+        _timeout: Duration,
     ) -> FullProposal {
         // Sleep before proposing the value so we don't produce blocks too fast
         // tokio::time::sleep(Duration::from_millis(100)).await;
@@ -245,7 +245,7 @@ impl Proposer for ShardProposer {
         Validity::Valid // TODO: Validate proposer signature?
     }
 
-    async fn decide(&mut self, height: Height, round: Round, value: ShardHash) {
+    async fn decide(&mut self, _height: Height, _round: Round, value: ShardHash) {
         if let Some(proposal) = self.proposed_chunks.get(&value) {
             if let Some(tx_decision) = &self.tx_decision {
                 let _ = tx_decision.send(proposal.clone()).await;
@@ -389,7 +389,7 @@ impl Proposer for BlockProposer {
     }
 
     fn add_proposed_value(&mut self, full_proposal: &FullProposal) -> Validity {
-        if let Some(proto::full_proposal::ProposedValue::Block(block)) =
+        if let Some(proto::full_proposal::ProposedValue::Block(_block)) =
             full_proposal.proposed_value.clone()
         {
             self.proposed_blocks
@@ -398,7 +398,7 @@ impl Proposer for BlockProposer {
         Validity::Valid // TODO: Validate proposer signature?
     }
 
-    async fn decide(&mut self, height: Height, round: Round, value: ShardHash) {
+    async fn decide(&mut self, _height: Height, _round: Round, value: ShardHash) {
         if let Some(proposal) = self.proposed_blocks.get(&value) {
             if let Some(tx_decision) = &self.tx_decision {
                 let _ = tx_decision.send(proposal.clone()).await;
@@ -700,7 +700,7 @@ impl Consensus {
                 Ok(())
             }
 
-            ConsensusMsg::ReceivedProposalPart(part) => {
+            ConsensusMsg::ReceivedProposalPart(_part) => {
                 // TODO: implement
                 Ok(())
             }
@@ -913,11 +913,7 @@ impl Actor for Consensus {
         let name = if args.1.shard_id.shard_id() == 0 {
             format!("{:} Block", address_prefix)
         } else {
-            format!(
-                "{:} Shard {:}",
-                address_prefix,
-                shard_id = args.1.shard_id.shard_id()
-            )
+            format!("{:} Shard {:}", address_prefix, args.1.shard_id.shard_id())
         };
         Ok(State {
             timers: Timers::new(myself),

--- a/src/consensus/consensus.rs
+++ b/src/consensus/consensus.rs
@@ -48,7 +48,7 @@ impl<Ctx: Context + SnapchainContext> From<TimeoutElapsed<Timeout>> for Consensu
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
     pub private_key: String,
     pub shard_ids: String,
@@ -66,6 +66,10 @@ impl Config {
             .split(',')
             .map(|s| s.parse().unwrap())
             .collect()
+    }
+
+    pub fn num_shards(&self) -> u32 {
+        self.shard_ids.len() as u32
     }
 }
 

--- a/src/consensus/consensus.rs
+++ b/src/consensus/consensus.rs
@@ -29,10 +29,12 @@ pub use malachite_consensus::State as ConsensusState;
 use prost::Message;
 use serde::{Deserialize, Serialize};
 use tokio::time::Instant;
+use tokio::{select, time};
 
 pub type ConsensusRef<Ctx> = ActorRef<ConsensusMsg<Ctx>>;
 pub type Decision = FullProposal;
 pub type TxDecision = mpsc::Sender<Decision>;
+pub type RxDecision = mpsc::Receiver<Decision>;
 
 pub enum SystemMessage {
     Consensus(ConsensusMsg<SnapchainValidatorContext>),
@@ -49,6 +51,7 @@ impl<Ctx: Context + SnapchainContext> From<TimeoutElapsed<Timeout>> for Consensu
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Config {
     pub private_key: String,
+    pub shard_ids: String,
 }
 
 impl Config {
@@ -57,12 +60,20 @@ impl Config {
         let secret_key = SecretKey::try_from_bytes(bytes);
         Keypair::from(secret_key.unwrap())
     }
+
+    pub fn shard_ids(&self) -> Vec<u32> {
+        self.shard_ids
+            .split(',')
+            .map(|s| s.parse().unwrap())
+            .collect()
+    }
 }
 
 impl Default for Config {
     fn default() -> Self {
         Self {
             private_key: hex::encode(SecretKey::generate()),
+            shard_ids: "1".to_string(),
         }
     }
 }
@@ -86,6 +97,22 @@ pub enum ConsensusMsg<Ctx: SnapchainContext> {
     RegisterValidator(SnapchainValidator),
 
     TimeoutElapsed(TimeoutElapsed<Timeout>),
+}
+
+impl ConsensusMsg<SnapchainValidatorContext> {
+    pub fn shard_id(&self) -> u32 {
+        match self {
+            ConsensusMsg::StartHeight(height) => height.shard_index,
+            ConsensusMsg::ProposeValue(height, _, _, _) => height.shard_index,
+            ConsensusMsg::ReceivedProposedValue(proposed) => proposed.height.shard_index,
+            ConsensusMsg::ReceivedSignedVote(vote) => vote.height.shard_index,
+            ConsensusMsg::ReceivedSignedProposal(proposal) => proposal.height.shard_index,
+            ConsensusMsg::ReceivedFullProposal(full_proposal) => full_proposal.height().shard_index,
+            ConsensusMsg::RegisterValidator(validator) => validator.shard_index,
+
+            _ => panic!("Requested shard ID for unsupported message type"),
+        }
+    }
 }
 
 struct Timeouts {
@@ -123,7 +150,12 @@ impl Timeouts {
 
 pub trait Proposer {
     // Create a new block/shard chunk for the given height that will be proposed for confirmation to the other validators
-    fn propose_value(&mut self, height: Height, round: Round) -> FullProposal;
+    async fn propose_value(
+        &mut self,
+        height: Height,
+        round: Round,
+        timeout: Duration,
+    ) -> FullProposal;
     // Receive a block/shard chunk proposed by another validator and return whether it is valid
     fn add_proposed_value(&mut self, full_proposal: &FullProposal) -> Validity;
     // Consensus has confirmed the block/shard_chunk, apply it to the local state
@@ -138,10 +170,32 @@ pub struct ShardProposer {
     tx_decision: Option<TxDecision>,
 }
 
-impl ShardProposer {}
+impl ShardProposer {
+    pub fn new(
+        address: Address,
+        shard_id: SnapchainShard,
+        tx_decision: Option<TxDecision>,
+    ) -> ShardProposer {
+        ShardProposer {
+            shard_id,
+            address,
+            chunks: vec![],
+            proposed_chunks: BTreeMap::new(),
+            tx_decision,
+        }
+    }
+}
 
 impl Proposer for ShardProposer {
-    fn propose_value(&mut self, height: Height, round: Round) -> FullProposal {
+    async fn propose_value(
+        &mut self,
+        height: Height,
+        round: Round,
+        timeout: Duration,
+    ) -> FullProposal {
+        // Sleep before proposing the value so we don't produce blocks too fast
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
         let previous_chunk = self.chunks.last();
         let parent_hash = match previous_chunk {
             Some(chunk) => chunk.hash.clone(),
@@ -207,6 +261,8 @@ pub struct BlockProposer {
     address: Address,
     blocks: Vec<Block>,
     proposed_blocks: BTreeMap<ShardHash, FullProposal>,
+    shard_decision_rx: RxDecision,
+    num_shards: u32,
     tx_decision: Option<TxDecision>,
 }
 
@@ -214,6 +270,8 @@ impl BlockProposer {
     pub fn new(
         address: Address,
         shard_id: SnapchainShard,
+        shard_decision_rx: RxDecision,
+        num_shards: u32,
         tx_decision: Option<TxDecision>,
     ) -> BlockProposer {
         BlockProposer {
@@ -221,13 +279,70 @@ impl BlockProposer {
             address,
             blocks: vec![],
             proposed_blocks: BTreeMap::new(),
+            shard_decision_rx,
+            num_shards,
             tx_decision,
         }
+    }
+
+    async fn collect_confirmed_shard_chunks(
+        &mut self,
+        height: Height,
+        timeout: Duration,
+    ) -> Vec<ShardChunk> {
+        let mut confirmed_shard_chunks = vec![];
+
+        let mut poll_interval = time::interval(Duration::from_millis(10));
+
+        // convert to deadline
+        let deadline = Instant::now() + timeout;
+
+        loop {
+            let timeout = time::sleep_until(deadline);
+            select! {
+                _ = poll_interval.tick() => {
+                    if let Ok(decision) = self.shard_decision_rx.try_recv() {
+                       if let Some(proto::full_proposal::ProposedValue::Shard(chunk)) = decision.proposed_value {
+                            let chunk_block_number = chunk.header.clone().unwrap().height.unwrap().block_number;
+                            if chunk_block_number == height.block_number {
+                                confirmed_shard_chunks.push(chunk);
+                            }
+                        }
+                    }
+                    if confirmed_shard_chunks.len() == self.num_shards as usize {
+                        break;
+                    }
+                }
+                _ = timeout => {
+                    warn!("Block validator did not receive all shard chunks in time for height: {:?}", height);
+                    break;
+                }
+            }
+        }
+
+        // loop to wait for the shard decision until we reach the timeout
+        while let Ok(decision) = self.shard_decision_rx.try_recv() {
+            if let Some(proto::full_proposal::ProposedValue::Shard(chunk)) = decision.proposed_value
+            {
+                let chunk_block_number = chunk.header.clone().unwrap().height.unwrap().block_number;
+                if chunk_block_number == height.block_number {
+                    confirmed_shard_chunks.push(chunk);
+                }
+            }
+        }
+        confirmed_shard_chunks
     }
 }
 
 impl Proposer for BlockProposer {
-    fn propose_value(&mut self, height: Height, round: Round) -> FullProposal {
+    async fn propose_value(
+        &mut self,
+        height: Height,
+        round: Round,
+        timeout: Duration,
+    ) -> FullProposal {
+        let shard_chunks = self.collect_confirmed_shard_chunks(height, timeout).await;
+
         let previous_block = self.blocks.last();
         let parent_hash = match previous_block {
             Some(block) => block.hash.clone(),
@@ -254,7 +369,7 @@ impl Proposer for BlockProposer {
             hash: hash.clone(),
             validators: None,
             votes: None,
-            shard_chunks: vec![],
+            shard_chunks,
         };
 
         let shard_hash = ShardHash {
@@ -381,11 +496,16 @@ impl ShardValidator {
         }
     }
 
-    pub fn propose_value(&mut self, height: Height, round: Round) -> FullProposal {
+    pub async fn propose_value(
+        &mut self,
+        height: Height,
+        round: Round,
+        timeout: Duration,
+    ) -> FullProposal {
         if let Some(block_proposer) = &mut self.block_proposer {
-            block_proposer.propose_value(height, round)
+            block_proposer.propose_value(height, round, timeout).await
         } else if let Some(shard_proposer) = &mut self.shard_proposer {
-            shard_proposer.propose_value(height, round)
+            shard_proposer.propose_value(height, round, timeout).await
         } else {
             panic!("No proposer set");
         }
@@ -728,12 +848,10 @@ impl Consensus {
             }
 
             Effect::GetValue(height, round, timeout) => {
-                let timeout_duration = timeouts.duration_for(timeout.step);
-                let full_proposal = shard_validator.propose_value(height, round);
+                let timeout = timeouts.duration_for(timeout.step);
+                let full_proposal = shard_validator.propose_value(height, round, timeout).await;
 
                 let value = full_proposal.shard_hash();
-                // Sleep before proposing the value so we don't produce blocks too fast
-                tokio::time::sleep(Duration::from_millis(500)).await;
 
                 debug!("Proposing value: {value} for height: {height}, round: {round}");
                 let result = myself.cast(ConsensusMsg::ProposeValue(height, round, value, None));

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -14,7 +14,7 @@ use tracing::warn;
 pub use crate::proto::snapchain as proto; // TODO: reconsider how this is imported
 
 use crate::proto::snapchain::full_proposal::ProposedValue;
-use crate::proto::snapchain::FullProposal;
+use crate::proto::snapchain::{Block, FullProposal, ShardChunk};
 use proto::ShardHash;
 
 pub trait ShardId
@@ -213,7 +213,7 @@ impl malachite_common::Value for ShardHash {
 }
 
 impl FullProposal {
-    pub fn value(&self) -> ShardHash {
+    pub fn shard_hash(&self) -> ShardHash {
         match &self.proposed_value {
             Some(ProposedValue::Block(block)) => ShardHash {
                 shard_index: self.height().shard_index as u32,
@@ -226,6 +226,20 @@ impl FullProposal {
             _ => {
                 panic!("Invalid proposal type");
             }
+        }
+    }
+
+    pub fn block(&self) -> Option<Block> {
+        match &self.proposed_value {
+            Some(ProposedValue::Block(block)) => Some(block.clone()),
+            _ => None,
+        }
+    }
+
+    pub fn shard_chunk(&self) -> Option<ShardChunk> {
+        match &self.proposed_value {
+            Some(ProposedValue::Shard(chunk)) => Some(chunk.clone()),
+            _ => None,
         }
     }
 

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -104,11 +104,11 @@ impl malachite_common::SigningScheme for Ed25519 {
     type PublicKey = PublicKey;
     type PrivateKey = PrivateKey;
 
-    fn decode_signature(bytes: &[u8]) -> Result<Self::Signature, Self::DecodingError> {
+    fn decode_signature(_bytes: &[u8]) -> Result<Self::Signature, Self::DecodingError> {
         todo!()
     }
 
-    fn encode_signature(signature: &Self::Signature) -> Vec<u8> {
+    fn encode_signature(_signature: &Self::Signature) -> Vec<u8> {
         todo!()
     }
 }
@@ -572,11 +572,11 @@ impl malachite_common::Context for SnapchainValidatorContext {
 
     fn verify_signed_proposal_part(
         &self,
-        proposal_part: &ProposalPart,
-        signature: &Signature,
-        public_key: &PublicKey,
+        _proposal_part: &ProposalPart,
+        _signature: &Signature,
+        _public_key: &PublicKey,
     ) -> bool {
-        false
+        todo!()
     }
 
     fn new_proposal(

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -61,6 +61,10 @@ impl Address {
         bytes.copy_from_slice(&vec);
         Self(bytes)
     }
+
+    pub fn prefix(&self) -> String {
+        format!("0x{}", &self.to_hex()[0..4])
+    }
 }
 
 impl fmt::Display for Address {

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -21,18 +21,18 @@ pub trait ShardId
 where
     Self: Sized + Clone + Send + Sync + 'static,
 {
-    fn new(id: u8) -> Self;
-    fn shard_id(&self) -> u8;
+    fn new(id: u32) -> Self;
+    fn shard_id(&self) -> u32;
 }
 
 #[derive(Clone, Debug)]
-pub struct SnapchainShard(u8);
+pub struct SnapchainShard(u32);
 
 impl ShardId for SnapchainShard {
-    fn new(id: u8) -> Self {
+    fn new(id: u32) -> Self {
         Self(id)
     }
-    fn shard_id(&self) -> u8 {
+    fn shard_id(&self) -> u32 {
         self.0
     }
 }
@@ -121,12 +121,12 @@ impl Display for Hash {
 
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Height {
-    pub shard_index: u8,
+    pub shard_index: u32,
     pub block_number: u64,
 }
 
 impl Height {
-    pub const fn new(shard_index: u8, block_number: u64) -> Self {
+    pub const fn new(shard_index: u32, block_number: u64) -> Self {
         Self {
             shard_index,
             block_number,
@@ -135,7 +135,7 @@ impl Height {
 
     pub fn to_proto(&self) -> proto::Height {
         proto::Height {
-            shard_index: self.shard_index as u32,
+            shard_index: self.shard_index,
             block_number: self.block_number,
         }
     }
@@ -143,7 +143,7 @@ impl Height {
     pub(crate) fn from_proto(proto: proto::Height) -> Self {
         Self {
             block_number: proto.block_number,
-            shard_index: proto.shard_index as u8,
+            shard_index: proto.shard_index,
         }
     }
 
@@ -258,7 +258,7 @@ impl FullProposal {
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SnapchainValidator {
-    pub shard_index: u8,
+    pub shard_index: u32,
     pub address: Address,
     pub public_key: PublicKey,
     pub rpc_address: Option<String>,
@@ -313,7 +313,7 @@ impl SnapchainValidatorSet {
         self.validators.iter().any(|v| v.address == *address)
     }
 
-    pub fn shard_id(&self) -> u8 {
+    pub fn shard_id(&self) -> u32 {
         if self.validators.is_empty() {
             0
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod connectors;
 pub mod consensus;
 pub mod core;
 pub mod network;
+pub mod node;
 
 mod tests;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,7 +150,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     };
 
     let ctx = SnapchainValidatorContext::new(keypair.clone());
-    let block_proposer = BlockProposer::new(validator_address.clone(), shard.clone());
+    let block_proposer = BlockProposer::new(validator_address.clone(), shard.clone(), None);
     let shard_validator =
         ShardValidator::new(validator_address.clone(), Some(block_proposer), None);
     let consensus_actor = Consensus::spawn(
@@ -159,7 +159,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         consensus_params,
         TimeoutConfig::default(),
         metrics.clone(),
-        None,
         gossip_tx.clone(),
         shard_validator,
     )

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-use malachite_config::TimeoutConfig;
 use malachite_metrics::{Metrics, SharedRegistry};
 use std::error::Error;
 use std::net::SocketAddr;
@@ -10,13 +9,8 @@ use tonic::transport::Server;
 use tracing::{error, info};
 use tracing_subscriber::EnvFilter;
 
-use snapchain::consensus::consensus::{
-    BlockProposer, Consensus, ConsensusParams, Decision, ShardValidator, SystemMessage,
-};
-use snapchain::core::types::{
-    proto, Address, Height, ShardId, SnapchainShard, SnapchainValidator, SnapchainValidatorContext,
-    SnapchainValidatorSet,
-};
+use snapchain::consensus::consensus::SystemMessage;
+use snapchain::core::types::proto;
 use snapchain::network::gossip::GossipEvent;
 use snapchain::network::gossip::SnapchainGossip;
 use snapchain::network::server::MySnapchainService;
@@ -127,7 +121,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     });
 
     let registry = SharedRegistry::global();
-    let metrics = Metrics::register(registry);
+    // Use the new non-global metrics registry when we upgrade to newer version of malachite
+    let _ = Metrics::register(registry);
 
     let node = SnapchainNode::create(
         keypair.clone(),

--- a/src/network/gossip.rs
+++ b/src/network/gossip.rs
@@ -131,7 +131,7 @@ impl SnapchainGossip {
                         },
                         SwarmEvent::Behaviour(SnapchainBehaviorEvent::Gossipsub(gossipsub::Event::Message {
                             propagation_source: peer_id,
-                            message_id: id,
+                            message_id: _id,
                             message,
                         })) => {
                             match proto::GossipMessage::decode(&message.data[..]) {
@@ -194,7 +194,6 @@ impl SnapchainGossip {
 
                                         }
                                         _ => warn!("Unhandled message from peer: {}", peer_id),
-                                        None => warn!("Received empty gossip message from peer: {}", peer_id),
                                     }
                                 },
                                 Err(e) => warn!("Failed to decode gossip message: {}", e),

--- a/src/network/gossip.rs
+++ b/src/network/gossip.rs
@@ -155,7 +155,8 @@ impl SnapchainGossip {
                                                     continue;
                                                 }
                                                 let rpc_address = validator.rpc_address;
-                                                let validator = SnapchainValidator::new(SnapchainShard::new(0), public_key.unwrap(), Some(rpc_address));
+                                                let shard_index = validator.shard_index;
+                                                let validator = SnapchainValidator::new(SnapchainShard::new(shard_index), public_key.unwrap(), Some(rpc_address));
                                                 let consensus_message = ConsensusMsg::RegisterValidator(validator);
                                                 let res = self.system_tx.send(SystemMessage::Consensus(consensus_message)).await;
                                                 if let Err(e) = res {

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -1,10 +1,7 @@
 use crate::proto::message::Message;
 use crate::proto::rpc::snapchain_service_server::{SnapchainService, SnapchainServiceServer};
 use hex::ToHex;
-use std::error::Error;
-use std::net::SocketAddr;
-use tonic::Code::Unimplemented;
-use tonic::{transport::Server, Request, Response, Status};
+use tonic::{Request, Response, Status};
 use tracing::info;
 
 #[derive(Default)]

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -1,0 +1,1 @@
+pub mod snapchain_node;

--- a/src/node/snapchain_node.rs
+++ b/src/node/snapchain_node.rs
@@ -13,7 +13,7 @@ use malachite_metrics::Metrics;
 use ractor::ActorRef;
 use std::collections::BTreeMap;
 use tokio::sync::mpsc;
-use tracing::warn;
+use tracing::{info, warn};
 
 const MAX_SHARDS: u32 = 3;
 
@@ -64,11 +64,15 @@ impl SnapchainNode {
                 shard.clone(),
                 Some(shard_decision_tx.clone()),
             );
-            let shard_validator =
-                ShardValidator::new(validator_address.clone(), None, Some(shard_proposer));
+            let shard_validator = ShardValidator::new(
+                validator_address.clone(),
+                shard.clone(),
+                None,
+                Some(shard_proposer),
+            );
             let consensus_actor = Consensus::spawn(
                 ctx,
-                shard,
+                shard.clone(),
                 shard_consensus_params,
                 TimeoutConfig::default(),
                 Metrics::new(),
@@ -106,8 +110,12 @@ impl SnapchainNode {
             num_shards,
             Some(block_decision_tx),
         );
-        let block_validator =
-            ShardValidator::new(validator_address.clone(), Some(block_proposer), None);
+        let block_validator = ShardValidator::new(
+            validator_address.clone(),
+            block_shard.clone(),
+            Some(block_proposer),
+            None,
+        );
         let ctx = SnapchainValidatorContext::new(keypair.clone());
         let block_consensus_actor = Consensus::spawn(
             ctx,

--- a/src/node/snapchain_node.rs
+++ b/src/node/snapchain_node.rs
@@ -1,0 +1,158 @@
+use crate::consensus::consensus::{
+    BlockProposer, Config, Consensus, ConsensusMsg, ConsensusParams, Decision, ShardProposer,
+    ShardValidator,
+};
+use crate::core::types::{
+    Address, Height, ShardId, SnapchainShard, SnapchainValidator, SnapchainValidatorContext,
+    SnapchainValidatorSet,
+};
+use crate::network::gossip::GossipEvent;
+use libp2p::identity::ed25519::Keypair;
+use malachite_config::TimeoutConfig;
+use malachite_metrics::Metrics;
+use ractor::ActorRef;
+use std::collections::BTreeMap;
+use tokio::sync::mpsc;
+use tracing::warn;
+
+const MAX_SHARDS: u32 = 3;
+
+pub struct SnapchainNode {
+    pub consensus_actors: BTreeMap<u32, ActorRef<ConsensusMsg<SnapchainValidatorContext>>>,
+    pub block_decision_rx: mpsc::Receiver<Decision>,
+}
+
+impl SnapchainNode {
+    pub async fn create(
+        keypair: Keypair,
+        config: Config,
+        rpc_address: Option<String>,
+        gossip_tx: mpsc::Sender<GossipEvent<SnapchainValidatorContext>>,
+    ) -> Self {
+        let validator_address = Address(keypair.public().to_bytes());
+
+        let mut consensus_actors = BTreeMap::new();
+        let num_shards = config.shard_ids().len() as u32;
+
+        let (shard_decision_tx, shard_decision_rx) = mpsc::channel::<Decision>(100);
+        let (block_decision_tx, block_decision_rx) = mpsc::channel::<Decision>(100);
+
+        // Create the shard validators
+        for shard_id in config.shard_ids() {
+            if shard_id == 0 {
+                panic!("Shard ID 0 is reserved for the block shard, created automaticaly");
+            } else if shard_id > MAX_SHARDS {
+                panic!("Shard ID must be between 1 and 3");
+            }
+
+            let shard = SnapchainShard::new(shard_id);
+            let shard_validator = SnapchainValidator::new(
+                shard.clone(),
+                keypair.public().clone(),
+                rpc_address.clone(),
+            );
+            let shard_validator_set = SnapchainValidatorSet::new(vec![shard_validator]);
+            let shard_consensus_params = ConsensusParams {
+                start_height: Height::new(shard.shard_id(), 1),
+                initial_validator_set: shard_validator_set,
+                address: validator_address.clone(),
+                threshold_params: Default::default(),
+            };
+            let ctx = SnapchainValidatorContext::new(keypair.clone());
+            let shard_proposer = ShardProposer::new(
+                validator_address.clone(),
+                shard.clone(),
+                Some(shard_decision_tx.clone()),
+            );
+            let shard_validator =
+                ShardValidator::new(validator_address.clone(), None, Some(shard_proposer));
+            let consensus_actor = Consensus::spawn(
+                ctx,
+                shard,
+                shard_consensus_params,
+                TimeoutConfig::default(),
+                Metrics::new(),
+                gossip_tx.clone(),
+                shard_validator,
+            )
+            .await
+            .unwrap();
+
+            consensus_actors.insert(shard_id, consensus_actor);
+        }
+
+        // Now create the block validator
+        let block_shard = SnapchainShard::new(0);
+
+        // We might want to use different keys for the block shard so signatures are different and cannot be accidentally used in the wrong shard
+        let block_validator = SnapchainValidator::new(
+            block_shard.clone(),
+            keypair.public().clone(),
+            rpc_address.clone(),
+        );
+        let block_validator_set = SnapchainValidatorSet::new(vec![block_validator]);
+
+        let block_consensus_params = ConsensusParams {
+            start_height: Height::new(block_shard.shard_id(), 1),
+            initial_validator_set: block_validator_set,
+            address: validator_address.clone(),
+            threshold_params: Default::default(),
+        };
+
+        let block_proposer = BlockProposer::new(
+            validator_address.clone(),
+            block_shard.clone(),
+            shard_decision_rx,
+            num_shards,
+            Some(block_decision_tx),
+        );
+        let block_validator =
+            ShardValidator::new(validator_address.clone(), Some(block_proposer), None);
+        let ctx = SnapchainValidatorContext::new(keypair.clone());
+        let block_consensus_actor = Consensus::spawn(
+            ctx,
+            block_shard,
+            block_consensus_params,
+            TimeoutConfig::default(),
+            Metrics::new(),
+            gossip_tx.clone(),
+            block_validator,
+        )
+        .await
+        .unwrap();
+        consensus_actors.insert(0, block_consensus_actor);
+
+        Self {
+            consensus_actors,
+            block_decision_rx,
+        }
+    }
+
+    pub fn stop(&self) {
+        // Stop all actors
+        for (_, actor) in self.consensus_actors.iter() {
+            actor.stop(None);
+        }
+    }
+
+    pub fn start_height(&self, block_number: u64) {
+        for (shard, actor) in self.consensus_actors.iter() {
+            let result = actor.cast(ConsensusMsg::StartHeight(Height::new(*shard, block_number)));
+            if let Err(e) = result {
+                panic!("Failed to start height: {:?}", e);
+            }
+        }
+    }
+
+    pub fn dispatch(&self, msg: ConsensusMsg<SnapchainValidatorContext>) {
+        let shard_id = msg.shard_id();
+        if let Some(actor) = self.consensus_actors.get(&shard_id) {
+            let result = actor.cast(msg);
+            if let Err(e) = result {
+                panic!("Failed to forward message to actor: {:?}", e);
+            }
+        } else {
+            panic!("No actor found for shard, could not forward message");
+        }
+    }
+}

--- a/src/node/snapchain_node.rs
+++ b/src/node/snapchain_node.rs
@@ -13,7 +13,6 @@ use malachite_metrics::Metrics;
 use ractor::ActorRef;
 use std::collections::BTreeMap;
 use tokio::sync::mpsc;
-use tracing::{info, warn};
 
 const MAX_SHARDS: u32 = 3;
 

--- a/src/proto/blocks.proto
+++ b/src/proto/blocks.proto
@@ -7,6 +7,7 @@ message Validator {
   uint64 fid = 1;
   bytes signer = 2;
   string rpc_address = 3;
+  uint32 shard_index = 4;
 }
 
 message ValidatorSet {

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -56,7 +56,7 @@ impl NodeForTest {
     }
 
     pub fn register_keypair(&self, keypair: Keypair) {
-        for i in 1..=self.num_shards {
+        for i in 0..=self.num_shards {
             self.cast(ConsensusMsg::RegisterValidator(SnapchainValidator::new(
                 SnapchainShard::new(i),
                 keypair.public().clone(),
@@ -121,7 +121,7 @@ async fn test_basic_consensus() {
     // Wait for gossip messages with a timeout
     let timeout = tokio::time::Duration::from_secs(5);
     let start = tokio::time::Instant::now();
-    let mut timer = time::interval(tokio::time::Duration::from_secs(1));
+    let mut timer = time::interval(tokio::time::Duration::from_millis(10));
 
     // create a lambda function to assert on the proposal
     let assert_valid_block = |decision: &Decision| match decision {
@@ -216,6 +216,11 @@ async fn test_basic_consensus() {
                         node2.cast(ConsensusMsg::ReceivedFullProposal(full_proposal.clone()));;
                     }
                     _ => {}}
+            }
+            _ = timer.tick() => {
+                if start.elapsed() > timeout {
+                    break;
+                }
             }
         }
     }

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -1,11 +1,11 @@
 use libp2p::identity::ed25519::Keypair;
-use malachite_config::TimeoutConfig;
-use malachite_consensus::Params as ConsensusParams;
 use malachite_metrics::{Metrics, SharedRegistry};
-use ractor::{Actor, ActorRef};
-use snapchain::consensus::consensus::{BlockProposer, Decision, ShardValidator, TxDecision};
+use ractor::ActorRef;
+use snapchain::consensus::consensus::{Decision, ShardProposer, ShardValidator, TxDecision};
+use snapchain::core::types::proto;
+use snapchain::node::snapchain_node::SnapchainNode;
 use snapchain::{
-    consensus::consensus::{Consensus, ConsensusMsg},
+    consensus::consensus::ConsensusMsg,
     core::types::{
         Address, Height, ShardId, SnapchainShard, SnapchainValidator, SnapchainValidatorContext,
         SnapchainValidatorSet,
@@ -18,68 +18,55 @@ use tracing::debug;
 use tracing_subscriber::EnvFilter;
 
 struct NodeForTest {
-    shard: SnapchainShard,
     keypair: Keypair,
-    validator_set: SnapchainValidatorSet,
+    num_shards: u32,
+    node: SnapchainNode,
     gossip_rx: mpsc::Receiver<GossipEvent<SnapchainValidatorContext>>,
-    gossip_tx: mpsc::Sender<GossipEvent<SnapchainValidatorContext>>,
-    consensus_actor: ActorRef<ConsensusMsg<SnapchainValidatorContext>>,
-    decision_rx: mpsc::Receiver<Decision>,
 }
 
 impl NodeForTest {
-    pub async fn create(
-        shard: SnapchainShard,
-        keypair: Keypair,
-        validator_set: SnapchainValidatorSet,
-    ) -> Self {
-        let metrics = Metrics::new();
-
-        let address = Address(keypair.public().to_bytes());
-        let consensus_params = ConsensusParams {
-            start_height: Height::new(shard.shard_id(), 1),
-            initial_validator_set: validator_set.clone(),
-            address: address.clone(),
-            threshold_params: Default::default(),
-        };
-
-        // Create validator context
-        let ctx = SnapchainValidatorContext::new(keypair.clone());
+    pub async fn create(keypair: Keypair, num_shards: u32) -> Self {
+        let config = snapchain::consensus::consensus::Config::default();
 
         let (gossip_tx, gossip_rx) = mpsc::channel::<GossipEvent<SnapchainValidatorContext>>(100);
-        let (decision_tx, decision_rx) = mpsc::channel::<Decision>(100);
-        let block_proposer =
-            BlockProposer::new(address.clone(), shard.clone(), Some(decision_tx.clone()));
-        let shard_validator = ShardValidator::new(address.clone(), Some(block_proposer), None);
-        // Spawn consensus actor
-        let consensus_actor = Consensus::spawn(
-            ctx,
-            shard.clone(),
-            consensus_params,
-            TimeoutConfig::default(),
-            metrics.clone(),
-            gossip_tx.clone(),
-            shard_validator,
-        )
-        .await
-        .unwrap();
+        let node = SnapchainNode::create(keypair.clone(), config, None, gossip_tx).await;
+
         Self {
-            shard,
             keypair,
-            validator_set,
-            consensus_actor,
+            num_shards,
+            node,
             gossip_rx,
-            gossip_tx,
-            decision_rx,
         }
     }
 
+    pub async fn recv_block_decision(&mut self) -> Option<Decision> {
+        self.node.block_decision_rx.recv().await
+    }
+
+    pub async fn recv_gossip_event(&mut self) -> Option<GossipEvent<SnapchainValidatorContext>> {
+        self.gossip_rx.recv().await
+    }
+
     pub fn cast(&self, msg: ConsensusMsg<SnapchainValidatorContext>) {
-        self.consensus_actor.cast(msg).unwrap()
+        self.node.dispatch(msg)
+    }
+
+    pub fn start_height(&self, block_number: u64) {
+        self.node.start_height(block_number);
+    }
+
+    pub fn register_keypair(&self, keypair: Keypair) {
+        for i in 1..=self.num_shards {
+            self.cast(ConsensusMsg::RegisterValidator(SnapchainValidator::new(
+                SnapchainShard::new(i),
+                keypair.public().clone(),
+                None,
+            )));
+        }
     }
 
     pub fn stop(&self) {
-        self.consensus_actor.stop(None);
+        self.node.stop();
     }
 }
 
@@ -94,13 +81,11 @@ async fn test_basic_consensus() {
     let keypair2 = Keypair::generate();
     let keypair3 = Keypair::generate();
 
-    let validator1_address = Address(keypair1.public().to_bytes());
-
     // Set up shard and validators
     let shard = SnapchainShard::new(0);
-    let validator1 = SnapchainValidator::new(shard.clone(), keypair1.public().clone());
-    let validator2 = SnapchainValidator::new(shard.clone(), keypair2.public().clone());
-    let validator3 = SnapchainValidator::new(shard.clone(), keypair3.public().clone());
+    let validator1 = SnapchainValidator::new(shard.clone(), keypair1.public().clone(), None);
+    let validator2 = SnapchainValidator::new(shard.clone(), keypair2.public().clone(), None);
+    let validator3 = SnapchainValidator::new(shard.clone(), keypair3.public().clone(), None);
 
     // Create validator set with all validators
     let validator_set = SnapchainValidatorSet::new(vec![
@@ -108,28 +93,26 @@ async fn test_basic_consensus() {
         validator2.clone(),
         validator3.clone(),
     ]);
+    let num_shards = 1;
 
-    let mut node1 =
-        NodeForTest::create(shard.clone(), keypair1.clone(), validator_set.clone()).await;
-    let mut node2 =
-        NodeForTest::create(shard.clone(), keypair2.clone(), validator_set.clone()).await;
-    let mut node3 =
-        NodeForTest::create(shard.clone(), keypair3.clone(), validator_set.clone()).await;
+    let mut node1 = NodeForTest::create(keypair1.clone(), num_shards).await;
+    let mut node2 = NodeForTest::create(keypair2.clone(), num_shards).await;
+    let mut node3 = NodeForTest::create(keypair3.clone(), num_shards).await;
 
     // Register validators
-    for validator in validator_set.validators {
-        node1.cast(ConsensusMsg::RegisterValidator(validator.clone()));
-        node2.cast(ConsensusMsg::RegisterValidator(validator.clone()));
-        node3.cast(ConsensusMsg::RegisterValidator(validator.clone()));
+    for keypair in vec![keypair1, keypair2, keypair3] {
+        node1.register_keypair(keypair.clone());
+        node2.register_keypair(keypair.clone());
+        node3.register_keypair(keypair.clone());
     }
 
     //sleep 2 seconds to wait for validators to register
     tokio::time::sleep(time::Duration::from_secs(2)).await;
 
     // Kick off consensus
-    node1.cast(ConsensusMsg::StartHeight(Height::new(shard.shard_id(), 1)));
-    node2.cast(ConsensusMsg::StartHeight(Height::new(shard.shard_id(), 1)));
-    node3.cast(ConsensusMsg::StartHeight(Height::new(shard.shard_id(), 1)));
+    node1.start_height(1);
+    node2.start_height(1);
+    node3.start_height(1);
 
     let mut node1_blocks_count = 0;
     let mut node2_blocks_count = 0;
@@ -140,36 +123,53 @@ async fn test_basic_consensus() {
     let start = tokio::time::Instant::now();
     let mut timer = time::interval(tokio::time::Duration::from_secs(1));
 
+    // create a lambda function to assert on the proposal
+    let assert_valid_block = |decision: &Decision| match decision {
+        proposal => {
+            debug!(
+                "Decided block at height {}, round {}, value: {}",
+                proposal.height(),
+                proposal.round(),
+                proposal.shard_hash()
+            );
+            if let Some(proto::full_proposal::ProposedValue::Block(block)) =
+                proposal.clone().proposed_value
+            {
+                assert_eq!(block.shard_chunks.len(), 1);
+            }
+        }
+    };
+
     loop {
         select! {
-            Some(decision) = node1.decision_rx.recv() => {
-                match decision {
-                    proposal => {
-                        debug!("Node 1: Decided block at height {}, round {}, value: {}", proposal.height(), proposal.round(), proposal.shard_hash());
-                        node1_blocks_count += 1;
-                    }
-                }
+            Some(decision) = node1.recv_block_decision() => {
+                assert_valid_block(&decision);
+                node1_blocks_count += 1;
             }
-            Some(decision) = node2.decision_rx.recv() => {
-                match decision {
-                    proposal => {
-                        debug!("Node 2: Decided block at height {}, round {}, value: {}", proposal.height(), proposal.round(), proposal.shard_hash());
-                        node2_blocks_count += 1;
-                    }
-                }
+            Some(decision) = node2.recv_block_decision() => {
+                assert_valid_block(&decision);
+                node2_blocks_count += 1;
             }
-            Some(decision) = node3.decision_rx.recv() => {
-                match decision {
-                    proposal => {
-                        debug!("Node 3: Decided block at height {}, round {}, value: {}", proposal.height(), proposal.round(), proposal.shard_hash());
-                        node3_blocks_count += 1;
-                    }
-                }
+            Some(decision) = node3.recv_block_decision() => {
+                assert_valid_block(&decision);
+                node3_blocks_count += 1;
             }
 
+            _ = timer.tick() => {
+                if node1_blocks_count == 3 && node2_blocks_count == 3 && node3_blocks_count == 3 {
+                    break;
+                }
+                if start.elapsed() > timeout {
+                    break;
+                }
+            }
+        }
+
+        // Separate select because we can't borrow node twice
+        select! {
             // Wire up the gossip messages to the other nodes
             // TODO: dedup
-            Some(gossip_event) = node1.gossip_rx.recv() => {
+            Some(gossip_event) = node1.recv_gossip_event() => {
                 match gossip_event {
                     GossipEvent::BroadcastSignedProposal(proposal) => {
                         node2.cast(ConsensusMsg::ReceivedSignedProposal(proposal.clone()));
@@ -216,15 +216,6 @@ async fn test_basic_consensus() {
                         node2.cast(ConsensusMsg::ReceivedFullProposal(full_proposal.clone()));;
                     }
                     _ => {}}
-            }
-
-            _ = timer.tick() => {
-                if node1_blocks_count == 3 && node2_blocks_count == 3 && node3_blocks_count == 3 {
-                    break;
-                }
-                if start.elapsed() > timeout {
-                    break;
-                }
             }
         }
     }


### PR DESCRIPTION
Creates multiple shard validators within a single snapchain node. By default one for the block and one for a single shard. But can support multiple shards. 

Gossip/Consensus messages are forwarded to the appropriate shard validator. 

Blocks are only produced if shard chunks are confirmed for the same height.