### PR TITLE
Fix multiple shards and clean up tests

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -4,6 +4,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Custom type attributes required for malachite
     builder = builder
         .type_attribute("snapchain.ShardHash", "#[derive(Eq, PartialOrd, Ord)]")
+        .type_attribute("snapchain.Height", "#[derive(Copy, Eq, PartialOrd, Ord)]")
         // TODO: this generates a lot of code, perhaps choose specific structures
         .type_attribute(".", "#[derive(serde::Serialize, serde::Deserialize)]");
 

--- a/src/consensus/timers.rs
+++ b/src/consensus/timers.rs
@@ -24,7 +24,7 @@ struct Timer<Key, Msg> {
     generation: u64,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct TimeoutElapsed<Key> {
     key: Key,
     generation: u64,

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -15,7 +15,8 @@ pub use crate::proto::snapchain as proto; // TODO: reconsider how this is import
 
 use crate::proto::snapchain::full_proposal::ProposedValue;
 use crate::proto::snapchain::{Block, FullProposal, ShardChunk};
-use proto::ShardHash;
+pub use proto::Height;
+pub use proto::ShardHash;
 
 pub trait ShardId
 where
@@ -123,31 +124,11 @@ impl Display for Hash {
     }
 }
 
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Height {
-    pub shard_index: u32,
-    pub block_number: u64,
-}
-
 impl Height {
     pub const fn new(shard_index: u32, block_number: u64) -> Self {
         Self {
             shard_index,
             block_number,
-        }
-    }
-
-    pub fn to_proto(&self) -> proto::Height {
-        proto::Height {
-            shard_index: self.shard_index,
-            block_number: self.block_number,
-        }
-    }
-
-    pub(crate) fn from_proto(proto: proto::Height) -> Self {
-        Self {
-            block_number: proto.block_number,
-            shard_index: proto.shard_index,
         }
     }
 
@@ -252,7 +233,7 @@ impl FullProposal {
     }
 
     pub fn height(&self) -> Height {
-        Height::from_proto(self.height.clone().unwrap())
+        self.height.clone().unwrap()
     }
 
     pub fn round(&self) -> Round {
@@ -399,7 +380,7 @@ impl Vote {
             NilOrVal::Val(shard_hash) => Some(shard_hash.clone()),
         };
         proto::Vote {
-            height: Some(self.height.to_proto()),
+            height: Some(self.height.clone()),
             round: self.round.as_i64(),
             voter: self.voter.to_vec(),
             r#type: vote_type as i32,
@@ -419,7 +400,7 @@ impl Vote {
         };
         Self {
             vote_type,
-            height: Height::from_proto(proto.height.unwrap()),
+            height: proto.height.unwrap(),
             round: Round::new(proto.round),
             voter: Address::from_vec(proto.voter),
             shard_hash,
@@ -444,7 +425,7 @@ pub struct Proposal {
 impl Proposal {
     pub fn to_proto(&self) -> proto::Proposal {
         proto::Proposal {
-            height: Some(self.height.to_proto()),
+            height: Some(self.height),
             round: self.round.as_i64(),
             proposer: self.proposer.to_vec(),
             value: Some(self.shard_hash.clone()),
@@ -454,7 +435,7 @@ impl Proposal {
 
     pub fn from_proto(proto: proto::Proposal) -> Self {
         Self {
-            height: Height::from_proto(proto.height.unwrap()),
+            height: proto.height.unwrap(),
             round: Round::new(proto.round),
             shard_hash: proto.value.unwrap(),
             pol_round: Round::new(proto.pol_round),

--- a/src/node/snapchain_node.rs
+++ b/src/node/snapchain_node.rs
@@ -22,6 +22,7 @@ const MAX_SHARDS: u32 = 3;
 pub struct SnapchainNode {
     pub consensus_actors: BTreeMap<u32, ActorRef<ConsensusMsg<SnapchainValidatorContext>>>,
     pub messages_tx_by_shard: HashMap<u32, mpsc::Sender<message::Message>>,
+    pub address: Address,
 }
 
 impl SnapchainNode {
@@ -142,7 +143,12 @@ impl SnapchainNode {
         Self {
             consensus_actors,
             messages_tx_by_shard: shard_messages,
+            address: validator_address,
         }
+    }
+
+    pub fn id(&self) -> String {
+        self.address.prefix()
     }
 
     pub fn stop(&self) {

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
@@ -17,7 +18,7 @@ use snapchain::{
 use tokio::sync::{mpsc, Mutex};
 use tokio::{select, time};
 use tonic::transport::Server;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 use tracing_subscriber::EnvFilter;
 
 struct NodeForTest {
@@ -26,11 +27,13 @@ struct NodeForTest {
     node: SnapchainNode,
     gossip_rx: mpsc::Receiver<GossipEvent<SnapchainValidatorContext>>,
     block_store: Arc<Mutex<BlockStore>>,
+    grpc_addr: String,
 }
 
 impl NodeForTest {
     pub async fn create(keypair: Keypair, num_shards: u32, grpc_port: u32) -> Self {
-        let config = snapchain::consensus::consensus::Config::default();
+        let mut config = snapchain::consensus::consensus::Config::default();
+        config = config.with_shard_ids((1..=num_shards).collect());
 
         let (gossip_tx, gossip_rx) = mpsc::channel::<GossipEvent<SnapchainValidatorContext>>(100);
 
@@ -40,17 +43,18 @@ impl NodeForTest {
 
         let block_store = Arc::new(Mutex::new(BlockStore::new()));
         let write_block_store = block_store.clone();
-        let assert_valid_block = |block: &Block| {
+        let node_id = node.id();
+        let assert_valid_block = move |block: &Block| {
             let header = block.header.as_ref().unwrap();
             let message_count = block.shard_chunks[0].transactions[0].user_messages.len();
             info!(
                 hash = hex::encode(&block.hash),
                 height = header.height.as_ref().map(|h| h.block_number),
+                id = node_id,
                 message_count,
                 "decided block",
             );
-
-            assert_eq!(block.shard_chunks.len(), 1);
+            assert_eq!(block.shard_chunks.len(), num_shards as usize);
         };
         tokio::spawn(async move {
             while let Some(block) = block_rx.recv().await {
@@ -65,11 +69,12 @@ impl NodeForTest {
         let messages_tx = node.messages_tx_by_shard.get(&1u32).unwrap().clone();
 
         let rpc_server_block_store = block_store.clone();
+        let grpc_addr = format!("0.0.0.0:{}", grpc_port);
+        let addr = grpc_addr.clone();
         tokio::spawn(async move {
             let service = MySnapchainService::new(rpc_server_block_store, messages_tx);
 
-            let grpc_addr = format!("0.0.0.0:{}", grpc_port);
-            let grpc_socket_addr: SocketAddr = grpc_addr.parse().unwrap();
+            let grpc_socket_addr: SocketAddr = addr.parse().unwrap();
             let resp = Server::builder()
                 .add_service(SnapchainServiceServer::new(service))
                 .serve(grpc_socket_addr)
@@ -88,6 +93,7 @@ impl NodeForTest {
             node,
             gossip_rx,
             block_store,
+            grpc_addr: grpc_addr.clone(),
         }
     }
 
@@ -114,12 +120,116 @@ impl NodeForTest {
         }
     }
 
+    pub fn id(&self) -> String {
+        self.node.id()
+    }
+
     pub async fn num_blocks(&self) -> usize {
         self.block_store.lock().await.get_blocks(0, None).len()
     }
 
     pub fn stop(&self) {
         self.node.stop();
+    }
+}
+
+pub struct TestNetwork {
+    nodes: Vec<NodeForTest>,
+}
+
+impl TestNetwork {
+    // These networks can be created in parallel, so make sure the base port is far enough part to avoid conflicts
+    pub async fn create(num_nodes: u32, num_shards: u32, base_grpc_port: u32) -> Self {
+        let mut nodes = Vec::new();
+        let mut keypairs = Vec::new();
+        for i in 0..num_nodes {
+            let keypair = Keypair::generate();
+            keypairs.push(keypair.clone());
+            let node = NodeForTest::create(keypair, num_shards, base_grpc_port + i).await;
+            nodes.push(node);
+        }
+
+        // Register validators
+        for i in 0..num_nodes {
+            for keypair in keypairs.iter() {
+                nodes[i as usize]
+                    .register_keypair(keypair.clone(), format!("0.0.0.0:{}", base_grpc_port + i));
+            }
+        }
+        // Wait for the RegisterValidator message to be processed
+        tokio::time::sleep(time::Duration::from_millis(200)).await;
+
+        Self { nodes }
+    }
+
+    pub async fn produce_blocks(&mut self, num_blocks: u64) {
+        for node in self.nodes.iter_mut() {
+            node.start_height(1);
+        }
+
+        let timeout = tokio::time::Duration::from_secs(5);
+        let start = tokio::time::Instant::now();
+        let mut timer = time::interval(tokio::time::Duration::from_millis(10));
+
+        let num_nodes = self.nodes.len();
+
+        let mut node_ids_with_blocks = BTreeSet::new();
+        loop {
+            let _ = timer.tick().await;
+            for node in self.nodes.iter_mut() {
+                if node.num_blocks().await >= num_blocks as usize {
+                    node_ids_with_blocks.insert(node.id());
+                    if node_ids_with_blocks.len() == num_nodes {
+                        break;
+                    }
+                }
+            }
+
+            // Loop through each node, and select all other nodes to send gossip messages
+            for i in 0..self.nodes.len() {
+                if let Ok(gossip_event) = self.nodes[i].gossip_rx.try_recv() {
+                    match gossip_event {
+                        GossipEvent::BroadcastSignedProposal(proposal) => {
+                            self.dispatch_to_other_nodes(
+                                i,
+                                ConsensusMsg::ReceivedSignedProposal(proposal.clone()),
+                            );
+                        }
+                        GossipEvent::BroadcastSignedVote(vote) => {
+                            self.dispatch_to_other_nodes(
+                                i,
+                                ConsensusMsg::ReceivedSignedVote(vote.clone()),
+                            );
+                        }
+                        GossipEvent::BroadcastFullProposal(full_proposal) => {
+                            self.dispatch_to_other_nodes(
+                                i,
+                                ConsensusMsg::ReceivedFullProposal(full_proposal.clone()),
+                            );
+                        }
+                        _ => {}
+                    }
+                }
+            }
+
+            if start.elapsed() > timeout {
+                break;
+            }
+        }
+    }
+
+    fn dispatch_to_other_nodes(&self, i: usize, msg: ConsensusMsg<SnapchainValidatorContext>) {
+        for j in 0..self.nodes.len() {
+            if i != j {
+                self.nodes[j].cast(msg.clone());
+            }
+        }
+    }
+
+    pub fn stop(&self) {
+        for node in self.nodes.iter() {
+            node.stop();
+        }
     }
 }
 
@@ -130,260 +240,52 @@ async fn test_basic_consensus() {
         .with_env_filter(env_filter)
         .try_init();
 
-    // Create validator keys
-    let keypair1 = Keypair::generate();
-    let keypair2 = Keypair::generate();
-    let keypair3 = Keypair::generate();
+    let num_shards = 2;
+    let mut network = TestNetwork::create(3, num_shards, 3380).await;
 
-    let num_shards = 1;
-
-    let mut node1 = NodeForTest::create(keypair1.clone(), num_shards, 3381).await;
-    let mut node2 = NodeForTest::create(keypair2.clone(), num_shards, 3382).await;
-    let mut node3 = NodeForTest::create(keypair3.clone(), num_shards, 3383).await;
-
-    // Register validators
-    for keypair in vec![keypair1, keypair2, keypair3] {
-        node1.register_keypair(keypair.clone(), format!("0.0.0.0:{}", 3381));
-        node2.register_keypair(keypair.clone(), format!("0.0.0.0:{}", 3382));
-        node3.register_keypair(keypair.clone(), format!("0.0.0.0:{}", 3383));
-    }
-
-    //sleep 2 seconds to wait for validators to register
-    tokio::time::sleep(time::Duration::from_secs(2)).await;
-
-    let messages_tx1 = node1
-        .node
-        .messages_tx_by_shard
-        .get(&1u32)
-        .expect("message channel should exist")
-        .clone();
-
-    tokio::spawn(async move {
-        let mut i: i32 = 0;
-        loop {
-            info!(i, "sending message");
-            messages_tx1
-                .send(message::Message {
-                    hash: i.to_be_bytes().to_vec(), // just for now
-                    data: None,
-                    data_bytes: None,
-                    hash_scheme: message::HashScheme::Blake3 as i32,
-                    signature: vec![],
-                    signature_scheme: 0,
-                    signer: vec![],
-                })
-                .await
-                .unwrap();
-            i += 1;
-            tokio::time::sleep(time::Duration::from_millis(200)).await;
-        }
-    });
-
-    // Kick off consensus
-    node1.start_height(1);
-    node2.start_height(1);
-    node3.start_height(1);
-
-    // Wait for gossip messages with a timeout
-    let timeout = tokio::time::Duration::from_secs(5);
-    let start = tokio::time::Instant::now();
-    let mut timer = time::interval(tokio::time::Duration::from_millis(10));
-
-    loop {
-        select! {
-            // Wire up the gossip messages to the other nodes
-            // TODO: dedup
-            Some(gossip_event) = node1.recv_gossip_event() => {
-                match gossip_event {
-                    GossipEvent::BroadcastSignedProposal(proposal) => {
-                        node2.cast(ConsensusMsg::ReceivedSignedProposal(proposal.clone()));
-                        node3.cast(ConsensusMsg::ReceivedSignedProposal(proposal.clone()));
-                    },
-                    GossipEvent::BroadcastSignedVote(vote) => {
-                        node2.cast(ConsensusMsg::ReceivedSignedVote(vote.clone()));
-                        node3.cast(ConsensusMsg::ReceivedSignedVote(vote.clone()));
-                    }
-                    GossipEvent::BroadcastFullProposal(full_proposal) => {
-                        node2.cast(ConsensusMsg::ReceivedFullProposal(full_proposal.clone()));
-                        node3.cast(ConsensusMsg::ReceivedFullProposal(full_proposal.clone()));
-                    }
-                    _ => {}}
-            }
-            Some(gossip_event) = node2.gossip_rx.recv() => {
-                match gossip_event {
-                    GossipEvent::BroadcastSignedProposal(proposal) => {
-                        node1.cast(ConsensusMsg::ReceivedSignedProposal(proposal.clone()));
-                        node3.cast(ConsensusMsg::ReceivedSignedProposal(proposal.clone()));
-                    },
-                    GossipEvent::BroadcastSignedVote(vote) => {
-                        node1.cast(ConsensusMsg::ReceivedSignedVote(vote.clone()));
-                        node3.cast(ConsensusMsg::ReceivedSignedVote(vote.clone()));
-                    }
-                    GossipEvent::BroadcastFullProposal(full_proposal) => {
-                        node1.cast(ConsensusMsg::ReceivedFullProposal(full_proposal.clone()));
-                        node3.cast(ConsensusMsg::ReceivedFullProposal(full_proposal.clone()));
-                    }
-                    _ => {}}
-            }
-            Some(gossip_event) = node3.gossip_rx.recv() => {
-                match gossip_event {
-                    GossipEvent::BroadcastSignedProposal(proposal) => {
-                        node1.cast(ConsensusMsg::ReceivedSignedProposal(proposal.clone()));
-                        node2.cast(ConsensusMsg::ReceivedSignedProposal(proposal.clone()));
-                    },
-                    GossipEvent::BroadcastSignedVote(vote) => {
-                        node1.cast(ConsensusMsg::ReceivedSignedVote(vote.clone()));
-                        node2.cast(ConsensusMsg::ReceivedSignedVote(vote.clone()));
-                    }
-                    GossipEvent::BroadcastFullProposal(full_proposal) => {
-                        node1.cast(ConsensusMsg::ReceivedFullProposal(full_proposal.clone()));
-                        node2.cast(ConsensusMsg::ReceivedFullProposal(full_proposal.clone()));
-                    }
-                    _ => {}}
-            }
-            _ = timer.tick() => {
-                let stop = 3 * 3;
-
-                if node1.num_blocks().await == stop
-                    && node2.num_blocks().await == stop
-                    && node3.num_blocks().await == stop
-                {
-                    break;
-                }
-                if start.elapsed() > timeout {
-                    break;
-                }
-            }
-        }
-    }
+    network.produce_blocks(3).await;
 
     assert!(
-        node1.num_blocks().await >= 3,
+        network.nodes[0].num_blocks().await >= 3,
         "Node 1 should have confirmed blocks"
     );
     assert!(
-        node2.num_blocks().await >= 3,
+        network.nodes[1].num_blocks().await >= 3,
         "Node 2 should have confirmed blocks"
     );
     assert!(
-        node3.num_blocks().await >= 3,
+        network.nodes[2].num_blocks().await >= 3,
         "Node 3 should have confirmed blocks"
     );
 
     // Clean up
-    node1.stop();
-    node2.stop();
-    node3.stop();
+    network.stop();
 }
 
 #[tokio::test]
 async fn test_basic_block_sync() {
+    let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn"));
     let _ = tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::new("info"))
+        .with_env_filter(env_filter)
         .try_init();
 
-    // Create validator keys
-    let keypair1 = Keypair::generate();
-    let keypair2 = Keypair::generate();
-    let keypair3 = Keypair::generate();
     let keypair4 = Keypair::generate();
 
     // Set up shard and validators
 
     let num_shards = 1;
 
-    let mut node1 = NodeForTest::create(keypair1.clone(), num_shards, 3384).await;
-    let mut node2 = NodeForTest::create(keypair2.clone(), num_shards, 3385).await;
-    let mut node3 = NodeForTest::create(keypair3.clone(), num_shards, 3386).await;
+    let mut network = TestNetwork::create(3, num_shards, 3200).await;
 
-    // Register validators
-    for keypair in vec![keypair1.clone(), keypair2.clone(), keypair3.clone()] {
-        node1.register_keypair(keypair.clone(), format!("0.0.0.0:{}", 3384));
-        node2.register_keypair(keypair.clone(), format!("0.0.0.0:{}", 3385));
-        node3.register_keypair(keypair.clone(), format!("0.0.0.0:{}", 3386));
-    }
+    network.produce_blocks(3).await;
 
-    //sleep 2 seconds to wait for validators to register
-    tokio::time::sleep(time::Duration::from_secs(2)).await;
-
-    // Kick off consensus
-    node1.start_height(1);
-    node2.start_height(1);
-    node3.start_height(1);
-
-    // Wait for gossip messages with a timeout
-    let timeout = tokio::time::Duration::from_secs(5);
-    let start = tokio::time::Instant::now();
-    let mut timer = time::interval(tokio::time::Duration::from_millis(10));
-
-    loop {
-        // Separate select because we can't borrow node twice
-        select! {
-            // Wire up the gossip messages to the other nodes
-            // TODO: dedup
-            Some(gossip_event) = node1.recv_gossip_event() => {
-                match gossip_event {
-                    GossipEvent::BroadcastSignedProposal(proposal) => {
-                        node2.cast(ConsensusMsg::ReceivedSignedProposal(proposal.clone()));
-                        node3.cast(ConsensusMsg::ReceivedSignedProposal(proposal.clone()));
-                    },
-                    GossipEvent::BroadcastSignedVote(vote) => {
-                        node2.cast(ConsensusMsg::ReceivedSignedVote(vote.clone()));
-                        node3.cast(ConsensusMsg::ReceivedSignedVote(vote.clone()));
-                    }
-                    GossipEvent::BroadcastFullProposal(full_proposal) => {
-                        node2.cast(ConsensusMsg::ReceivedFullProposal(full_proposal.clone()));
-                        node3.cast(ConsensusMsg::ReceivedFullProposal(full_proposal.clone()));
-                    }
-                    _ => {}}
-            }
-            Some(gossip_event) = node2.gossip_rx.recv() => {
-                match gossip_event {
-                    GossipEvent::BroadcastSignedProposal(proposal) => {
-                        node1.cast(ConsensusMsg::ReceivedSignedProposal(proposal.clone()));
-                        node3.cast(ConsensusMsg::ReceivedSignedProposal(proposal.clone()));
-                    },
-                    GossipEvent::BroadcastSignedVote(vote) => {
-                        node1.cast(ConsensusMsg::ReceivedSignedVote(vote.clone()));
-                        node3.cast(ConsensusMsg::ReceivedSignedVote(vote.clone()));
-                    }
-                    GossipEvent::BroadcastFullProposal(full_proposal) => {
-                        node1.cast(ConsensusMsg::ReceivedFullProposal(full_proposal.clone()));
-                        node3.cast(ConsensusMsg::ReceivedFullProposal(full_proposal.clone()));
-                    }
-                    _ => {}}
-            }
-            Some(gossip_event) = node3.gossip_rx.recv() => {
-                match gossip_event {
-                    GossipEvent::BroadcastSignedProposal(proposal) => {
-                        node1.cast(ConsensusMsg::ReceivedSignedProposal(proposal.clone()));
-                        node2.cast(ConsensusMsg::ReceivedSignedProposal(proposal.clone()));
-                    },
-                    GossipEvent::BroadcastSignedVote(vote) => {
-                        node1.cast(ConsensusMsg::ReceivedSignedVote(vote.clone()));
-                        node2.cast(ConsensusMsg::ReceivedSignedVote(vote.clone()));
-                    }
-                    GossipEvent::BroadcastFullProposal(full_proposal) => {
-                        node1.cast(ConsensusMsg::ReceivedFullProposal(full_proposal.clone()));
-                        node2.cast(ConsensusMsg::ReceivedFullProposal(full_proposal.clone()));
-                    }
-                    _ => {}}
-            }
-            _ = timer.tick() => {
-                if start.elapsed() > timeout {
-                    break;
-                }
-            }
-        }
-    }
-
-    let node4 = NodeForTest::create(keypair4.clone(), num_shards, 3387).await;
-    node4.register_keypair(keypair4.clone(), format!("0.0.0.0:{}", 3387));
+    let node4 = NodeForTest::create(keypair4.clone(), num_shards, 3207).await;
+    node4.register_keypair(keypair4.clone(), format!("0.0.0.0:{}", 3207));
     node4.cast(ConsensusMsg::RegisterValidator(SnapchainValidator::new(
         SnapchainShard::new(0),
-        keypair1.public().clone(),
-        Some(format!("127.0.0.1:{}", 3384)),
-        node1.num_blocks().await as u64,
+        network.nodes[0].keypair.public().clone(),
+        Some(network.nodes[0].grpc_addr.clone()),
+        network.nodes[0].num_blocks().await as u64,
     )));
 
     let timeout = tokio::time::Duration::from_secs(5);
@@ -391,7 +293,7 @@ async fn test_basic_block_sync() {
     let mut timer = time::interval(tokio::time::Duration::from_millis(10));
     loop {
         let _ = timer.tick().await;
-        if node4.num_blocks().await >= node1.num_blocks().await {
+        if node4.num_blocks().await >= network.nodes[0].num_blocks().await {
             break;
         }
         if start.elapsed() > timeout {
@@ -400,25 +302,23 @@ async fn test_basic_block_sync() {
     }
 
     assert!(
-        node1.num_blocks().await >= 3,
+        network.nodes[0].num_blocks().await >= 3,
         "Node 1 should have confirmed blocks"
     );
     assert!(
-        node2.num_blocks().await >= 3,
+        network.nodes[1].num_blocks().await >= 3,
         "Node 2 should have confirmed blocks"
     );
     assert!(
-        node3.num_blocks().await >= 3,
+        network.nodes[2].num_blocks().await >= 3,
         "Node 3 should have confirmed blocks"
     );
     assert!(
-        node4.num_blocks().await >= node1.num_blocks().await,
+        node4.num_blocks().await >= network.nodes[0].num_blocks().await,
         "Node 4 should have confirmed blocks"
     );
 
     // Clean up
-    node1.stop();
-    node2.stop();
-    node3.stop();
+    network.stop();
     node4.stop();
 }


### PR DESCRIPTION
Creating a node with 2 shards wasn't working because the block proposer was using the length of the `shard_ids` string as the num_nodes instead of the length of the vector.

Reduced duplication in tests and made it easier to spin up a network of nodes.

Remove re-implementation of Height and used Height prost.