### PR TITLE
add follow-blocks script

### DIFF
--- a/config/Procfile
+++ b/config/Procfile
@@ -1,0 +1,6 @@
+ # e.g. goreman -f config/Procfile start
+
+ node1: RUSTFLAGS='-Awarnings' cargo run -- --id 1
+ node2: RUSTFLAGS='-Awarnings' cargo run -- --id 2
+ node3: RUSTFLAGS='-Awarnings' cargo run -- --id 3
+ node4: RUSTFLAGS='-Awarnings' cargo run -- --id 4

--- a/src/bin/follow-blocks.rs
+++ b/src/bin/follow-blocks.rs
@@ -1,0 +1,61 @@
+use hex;
+use snapchain::proto::rpc;
+use std::error::Error;
+use tokio::time;
+
+const FETCH_SIZE: u64 = 100;
+
+async fn follow_blocks(addr: String) -> Result<(), Box<dyn Error>> {
+    let mut client = rpc::snapchain_service_client::SnapchainServiceClient::connect(addr).await?;
+    let mut i = 1;
+
+    loop {
+        let msg = rpc::BlocksRequest {
+            shard_id: 1,
+            start_block_number: i,
+            stop_block_number: Some(i + FETCH_SIZE),
+        };
+
+        let request = tonic::Request::new(msg);
+        let response = client.get_blocks(request).await?;
+
+        let inner = response.into_inner();
+        if inner.blocks.is_empty() {
+            time::sleep(time::Duration::from_millis(10)).await;
+            continue;
+        }
+
+        for block in &inner.blocks {
+            let block_header = block.header.as_ref().ok_or("Block header missing")?;
+
+            let block_number = block_header
+                .height
+                .as_ref()
+                .ok_or("Block height missing")?
+                .block_number;
+
+            if block_number != i {
+                return Err("Unexpected block number found".into());
+            }
+
+            println!("Block {}", block_number);
+
+            for chunk in &block.shard_chunks {
+                for tx in &chunk.transactions {
+                    for msg in &tx.user_messages {
+                        let hash = hex::encode(&msg.hash);
+                        println!(" - {}", hash);
+                    }
+                }
+            }
+
+            i += 1;
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let addr = "http://127.0.0.1:50061".to_string();
+    follow_blocks(addr).await.unwrap();
+}


### PR DESCRIPTION
Add a simple script to monitor block production. With nodes running.

```
cargo run --bin follow-blocks
```

In a separate window, run:

```
cargo run --bin submit-message
```

You should see:

```
Block 24
Block 25
 - 5f892a992109a1c8b9a4e64a72bf815272887772
Block 26
Block 27
Block 28
Block 29
 - 18dd930fd57d79bf551d310721549b981026f42d
Block 30
Block 31
Block 32
Block 33
 - d555df45e7877e7d0ebf7df158b5c59e29021157
Block 34
Block 35
```