### PR TITLE
trie commit and rollback v0

### DIFF
--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -3,10 +3,11 @@ use crate::proto::snapchain::{Block, ShardChunk};
 use crate::proto::{message, snapchain};
 use crate::storage::db::RocksDB;
 use crate::storage::store::BlockStore;
+use crate::storage::trie::merkle_trie;
 use std::collections::HashMap;
 use std::iter;
 use tokio::sync::mpsc;
-use tracing::error;
+use tracing::{error, event, info, warn, Level};
 
 use super::shard::{self, ShardStore};
 
@@ -22,16 +23,37 @@ pub struct ShardEngine {
     shard_store: ShardStore,
     messages_rx: mpsc::Receiver<message::Message>,
     messages_tx: mpsc::Sender<message::Message>,
+    trie: merkle_trie::MerkleTrie,
+}
+
+fn encode_vec(data: &[Vec<u8>]) -> String {
+    data.iter()
+        .map(|vec| hex::encode(vec))
+        .collect::<Vec<String>>()
+        .join(", ")
 }
 
 impl ShardEngine {
     pub fn new(shard_id: u32, shard_store: ShardStore) -> ShardEngine {
+        // TODO: adding the trie here introduces many calls that want to return errors. Rethink unwrap strategy.
+
+        // TODO: refactor trie code to work with transactions only instead of having its own reference to the db (probably).
+        let trie = merkle_trie::MerkleTrie::new_with_db(shard_store.db.clone()).unwrap();
+        trie.initialize().unwrap();
+
+        // TODO: The empty trie currently has some issues with the newly added commit/rollback code. Remove when we can.
+        trie.insert(vec![vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9]])
+            .unwrap();
+        trie.commit().unwrap();
+        trie.reload().unwrap();
+
         let (messages_tx, messages_rx) = mpsc::channel::<message::Message>(10_000);
         ShardEngine {
             shard_id,
             shard_store,
             messages_rx,
             messages_tx,
+            trie,
         }
     }
 
@@ -40,8 +62,14 @@ impl ShardEngine {
     }
 
     pub fn propose_state_change(&mut self, shard: u32) -> ShardStateChange {
+        //TODO: return Result instead of .unwrap() ?
         let it = iter::from_fn(|| self.messages_rx.try_recv().ok());
         let user_messages: Vec<message::Message> = it.collect();
+
+        let mut hashes: Vec<Vec<u8>> = vec![];
+        for msg in &user_messages {
+            hashes.push(msg.hash.clone());
+        }
 
         let transactions = vec![snapchain::Transaction {
             fid: 1234,                      //TODO
@@ -50,6 +78,42 @@ impl ShardEngine {
             user_messages,
         }];
 
+        warn!(
+            shard,
+            insert = encode_vec(&hashes.clone()),
+            old_root_hash = hex::encode(self.trie.root_hash().unwrap()),
+            "propose – before insert",
+        );
+
+        self.trie.insert(hashes);
+        let new_root_hash = self.trie.root_hash().unwrap();
+        let count = self.trie.items().unwrap();
+
+        warn!(
+            shard,
+            new_state_root = hex::encode(&new_root_hash),
+            count,
+            "propose - after insert"
+        );
+
+        let result = ShardStateChange {
+            shard_id: shard,
+            new_state_root: new_root_hash.clone(),
+            transactions,
+        };
+
+        // TODO: this should probably operate automatically via drop trait
+        self.trie.reload().unwrap();
+
+        warn!(
+            shard,
+            reloaded_root_hash = hex::encode(&self.trie.root_hash().unwrap()),
+            count,
+            "propose - reloaded"
+        );
+
+        result
+
         // TODO:
         // Create a db transaction
         // For each user message, add to the store and merkle trie
@@ -57,24 +121,66 @@ impl ShardEngine {
         // Construct a ShardStateChange with the valid transactions and the new state root
         // Rollback the transaction
         // Return the state change
-
-        ShardStateChange {
-            shard_id: shard,
-            new_state_root: vec![],
-            transactions,
-        }
     }
 
-    pub fn validate_state_change(&mut self, _shard_state_change: &ShardStateChange) -> bool {
+    pub fn validate_state_change(&mut self, shard_state_change: &ShardStateChange) -> bool {
+        // TODO: actually validate
+
         // Create a db transaction
         // Replay the state change
         // If all messages merge successfully and the merkle trie root matches the stateroot in the state change, return true
         // Else return false
         // Rollback the transaction
-        true
+        true // TODO
     }
 
     pub fn commit_shard_chunk(&mut self, shard_chunk: ShardChunk) {
+        let shard_root = shard_chunk.clone().header.unwrap().shard_root; // TODO: without clone?
+
+        let mut hashes: Vec<Vec<u8>> = vec![];
+        // TODO! don't assume 1 transaction
+        for msg in &shard_chunk.transactions[0].user_messages {
+            hashes.push(msg.hash.clone());
+        }
+
+        let root0 = self.trie.root_hash().unwrap();
+
+        warn!(
+            state_root_0 = hex::encode(&root0),
+            insert = encode_vec(&hashes),
+            "commit insert"
+        );
+
+        self.trie.insert(hashes.clone()).unwrap();
+        let root1 = self.trie.root_hash().unwrap();
+
+        let hashes_match = &root1 == &shard_root;
+
+        warn!(
+            hashes_match,
+            state_root_0 = hex::encode(&root0),
+            state_root_1 = hex::encode(&root1),
+            shard_root = hex::encode(shard_root.clone()),
+            "commit 1"
+        );
+
+        if hashes_match {
+            self.trie.commit().unwrap();
+            let committed_root = self.trie.root_hash().unwrap();
+
+            self.trie.reload().unwrap();
+            let reloaded_root = self.trie.root_hash().unwrap();
+
+            error!(
+                committed_root = hex::encode(committed_root),
+                reloaded_root = hex::encode(reloaded_root),
+                "commit!"
+            );
+        } else {
+            error!("panic!");
+            panic!("hashes don't match")
+        }
+
         // Create a db transaction
         // Replay the state change
         // If the state root does not match or any of the messages fail to merge, panic?

--- a/src/storage/store/shard.rs
+++ b/src/storage/store/shard.rs
@@ -120,12 +120,12 @@ pub fn put_shard_chunk(db: &RocksDB, shard_chunk: ShardChunk) -> Result<(), Shar
 
 #[derive(Default)]
 pub struct ShardStore {
-    db: RocksDB,
+    pub db: Arc<RocksDB>, // TODO: pub and Arc are temporary to allow trie to use
 }
 
 impl ShardStore {
     pub fn new(db: RocksDB) -> ShardStore {
-        ShardStore { db }
+        ShardStore { db: Arc::new(db) }
     }
 
     pub fn put_shard_chunk(&self, shard_chunk: ShardChunk) -> Result<(), ShardStorageError> {

--- a/src/storage/trie/commit_rollback_tests.rs
+++ b/src/storage/trie/commit_rollback_tests.rs
@@ -1,0 +1,99 @@
+#[cfg(test)]
+mod tests {
+    use crate::storage::hub_error::HubError;
+    use crate::storage::trie::merkle_trie::MerkleTrie;
+    use hex;
+    use rand::{seq::SliceRandom, thread_rng};
+    use tempfile::TempDir;
+
+    fn generate_hashes(seed: Vec<u8>, chain_size: usize) -> Vec<Vec<u8>> {
+        let mut hash_chain = Vec::new();
+        let mut current_hash = seed;
+
+        for _ in 0..chain_size {
+            let hash = blake3::hash(&current_hash);
+            hash_chain.push(hash.as_bytes()[..20].to_vec());
+            current_hash = hash.as_bytes()[..20].to_vec();
+        }
+
+        hash_chain
+    }
+
+    #[test]
+    fn test_merkle_trie_basic_operations() -> Result<(), HubError> {
+        let dir = TempDir::new()?;
+        let db_path = dir.path().join("a.db");
+        let mut t = MerkleTrie::new(db_path.to_str().unwrap())?;
+        t.initialize()?;
+
+        t.insert(vec![
+            vec![1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            vec![2, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        ])?;
+
+        t.commit();
+
+        println!(
+            "After commit: root_hash = {}, values = {:?}",
+            hex::encode(t.root_hash()?),
+            t.get_all_values(&[])?
+        );
+
+        t.insert(vec![vec![3, 0, 0, 0, 0, 0, 0, 0, 0, 0]])?;
+        println!(
+            "After insert: root_hash = {}, values = {:?}",
+            hex::encode(t.root_hash()?),
+            t.get_all_values(&[])?
+        );
+
+        t.reload()?;
+        println!(
+            "After reload: root_hash = {}, values = {:?}",
+            hex::encode(t.root_hash()?),
+            t.get_all_values(&[])?
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_merkle_trie_with_large_data() -> Result<(), HubError> {
+        let dir = TempDir::new()?;
+        let hashes1 = generate_hashes(vec![1], 10_000);
+
+        let hashes2 = {
+            let mut rng = thread_rng();
+            let mut hashes = hashes1.clone();
+            hashes.shuffle(&mut rng);
+            hashes
+        };
+
+        {
+            let db_path = dir.path().join("t1.db");
+            let t1 = MerkleTrie::new(db_path.to_str().unwrap())?;
+            t1.initialize()?;
+            t1.insert(hashes1.clone())?;
+            let items = t1.items()?;
+            println!(
+                "t1: items = {:?}, root_hash = {}",
+                items,
+                hex::encode(t1.root_hash()?)
+            );
+        }
+
+        {
+            let db_path = dir.path().join("t2.db");
+            let t2 = MerkleTrie::new(db_path.to_str().unwrap())?;
+            t2.initialize()?;
+            t2.insert(hashes1)?;
+            let items = t2.items()?;
+            println!(
+                "t2: items = {:?}, root_hash = {}",
+                items,
+                hex::encode(t2.root_hash()?)
+            );
+        }
+
+        Ok(())
+    }
+}

--- a/src/storage/trie/mod.rs
+++ b/src/storage/trie/mod.rs
@@ -6,3 +6,6 @@ mod trie_node_tests;
 
 #[cfg(test)]
 mod merkle_trie_tests;
+
+#[cfg(test)]
+mod commit_rollback_tests;


### PR DESCRIPTION
This is a little messy but it does a few things:

- hashes of messages are added to the trie during propose, then rolled back
- hashes are again added during commit, and we check that the hashes match before committing or (for not at least) panicking

Still a lot to do but POC somewhat validated.