### PR TITLE
Add cli argument to optionally clear the db

### DIFF
--- a/src/bin/setup.rs
+++ b/src/bin/setup.rs
@@ -20,7 +20,7 @@ async fn main() {
             std::fs::create_dir(format!("nodes/{id}")).expect("Failed to create node directory");
         } else {
             if std::path::Path::new(db_dir.clone().as_str()).exists() {
-                std::fs::remove_dir(db_dir.clone()).expect("Failed to remove .rocks directory");
+                std::fs::remove_dir_all(db_dir.clone()).expect("Failed to remove .rocks directory");
             }
         }
         let secret_key = hex::encode(SecretKey::generate());

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -18,6 +18,7 @@ pub struct Config {
     pub gossip: network::gossip::Config,
     pub rpc_address: String,
     pub rocksdb_dir: String,
+    pub clear_db: bool,
 }
 
 impl Default for Config {
@@ -31,6 +32,7 @@ impl Default for Config {
             gossip: network::gossip::Config::default(),
             rpc_address: "0.0.0.0:3383".to_string(),
             rocksdb_dir: ".rocks".to_string(),
+            clear_db: false,
         }
     }
 }
@@ -45,6 +47,9 @@ pub struct CliArgs {
 
     #[arg(long, help = "Path to the config file")]
     config_path: Option<String>,
+
+    #[arg(long, action, help = "Start the node with a clean database")]
+    clear_db: bool,
     // All new arguments that are to override values from config files or environment variables
     // should be probably be optional (`Option<T>`) and without a default. Setting a default
     // in this case will have the effect of automatically overriding all previous configuration
@@ -84,6 +89,7 @@ pub fn load_and_merge_config(args: Vec<String>) -> Result<Config, Box<dyn Error>
     if let Some(log_format) = cli_args.log_format {
         config.log_format = log_format;
     }
+    config.clear_db = cli_args.clear_db;
 
     Ok(config)
 }

--- a/src/consensus/proposer.rs
+++ b/src/consensus/proposer.rs
@@ -5,20 +5,18 @@ use crate::core::types::{
 use crate::proto::rpc::snapchain_service_client::SnapchainServiceClient;
 use crate::proto::rpc::BlocksRequest;
 use crate::proto::snapchain::{Block, BlockHeader, FullProposal, ShardChunk, ShardHeader};
-use crate::proto::{message, snapchain};
 use crate::storage::store::engine::{Engine, ShardStateChange, SnapchainEngine};
-use crate::storage::store::{BlockStorageError, BlockStore};
+use crate::storage::store::BlockStorageError;
 use malachite_common::{Round, Validity};
 use prost::Message;
 use std::collections::BTreeMap;
-use std::iter;
 use std::time::Duration;
 use thiserror::Error;
 use tokio::sync::mpsc;
 use tokio::time::Instant;
 use tokio::{select, time};
 use tonic::Request;
-use tracing::{debug, error, warn};
+use tracing::{error, warn};
 
 const FARCASTER_EPOCH: u64 = 1609459200; // January 1, 2021 UTC
 

--- a/src/consensus/validator.rs
+++ b/src/consensus/validator.rs
@@ -1,4 +1,4 @@
-use crate::consensus::proposer::{BlockProposer, BlockProposerError, Proposer, ShardProposer};
+use crate::consensus::proposer::{BlockProposer, Proposer, ShardProposer};
 use crate::core::types::{
     Address, Height, ShardHash, ShardId, SnapchainShard, SnapchainValidator,
     SnapchainValidatorContext, SnapchainValidatorSet,

--- a/src/utils/cli.rs
+++ b/src/utils/cli.rs
@@ -1,8 +1,7 @@
 use crate::proto::message;
 use crate::proto::rpc::snapchain_service_client::SnapchainServiceClient;
 use crate::proto::{rpc, snapchain::Block};
-use ed25519_dalek::{SecretKey, Signer, SigningKey};
-use hex::FromHex;
+use ed25519_dalek::{Signer, SigningKey};
 use message::CastType::Cast;
 use message::MessageType::CastAdd;
 use message::{CastAddBody, FarcasterNetwork, MessageData};


### PR DESCRIPTION
Allows starting nodes with `--clear-db` that will delete all existing local state to make it easier to test