### PR TITLE
store on chain events from the engine

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -14,6 +14,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "src/proto/blocks.proto",
             "src/proto/rpc.proto",
             "src/proto/message.proto",
+            "src/proto/onchain_event.proto",
             "src/proto/hub_event.proto",
             "src/proto/username_proof.proto",
             "src/proto/sync_trie.proto",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,4 +33,8 @@ pub mod proto {
     pub mod sync_trie {
         tonic::include_proto!("sync_trie");
     }
+
+    pub mod onchain_event {
+        tonic::include_proto!("onchain_event");
+    }
 }

--- a/src/node/snapchain_node.rs
+++ b/src/node/snapchain_node.rs
@@ -9,7 +9,7 @@ use crate::network::gossip::GossipEvent;
 use crate::proto::msg as message;
 use crate::proto::snapchain::{Block, ShardChunk};
 use crate::storage::db::RocksDB;
-use crate::storage::store::engine::{BlockEngine, ShardEngine};
+use crate::storage::store::engine::{BlockEngine, Message, ShardEngine};
 use crate::storage::store::shard::ShardStore;
 use crate::storage::store::BlockStore;
 use libp2p::identity::ed25519::Keypair;
@@ -24,7 +24,7 @@ const MAX_SHARDS: u32 = 3;
 
 pub struct SnapchainNode {
     pub consensus_actors: BTreeMap<u32, ActorRef<ConsensusMsg<SnapchainValidatorContext>>>,
-    pub messages_tx_by_shard: HashMap<u32, mpsc::Sender<message::Message>>,
+    pub messages_tx_by_shard: HashMap<u32, mpsc::Sender<Message>>,
     pub shard_stores: HashMap<u32, ShardStore>,
     pub address: Address,
 }
@@ -45,7 +45,7 @@ impl SnapchainNode {
 
         let (shard_decision_tx, shard_decision_rx) = mpsc::channel::<ShardChunk>(100);
 
-        let mut shard_messages: HashMap<u32, mpsc::Sender<message::Message>> = HashMap::new();
+        let mut shard_messages: HashMap<u32, mpsc::Sender<Message>> = HashMap::new();
 
         let mut shard_stores: HashMap<u32, ShardStore> = HashMap::new();
 

--- a/src/proto/blocks.proto
+++ b/src/proto/blocks.proto
@@ -119,9 +119,70 @@ message Transaction {
   bytes account_root = 4; // State root for the account after applying the transaction for the fid
 }
 
-// OnChain events
-message OnChainEvent {
+enum OnChainEventType {
+  EVENT_TYPE_NONE = 0;
+  EVENT_TYPE_SIGNER = 1;
+  EVENT_TYPE_SIGNER_MIGRATED = 2;
+  EVENT_TYPE_ID_REGISTER = 3;
+  EVENT_TYPE_STORAGE_RENT = 4;
+}
 
+message OnChainEvent {
+  OnChainEventType type = 1;
+  uint32 chain_id = 2;
+  uint32 block_number = 3;
+  bytes block_hash = 4;
+  uint64 block_timestamp = 5;
+  bytes transaction_hash = 6;
+  uint32 log_index = 7;
+  uint64 fid = 8;
+  oneof body {
+    SignerEventBody signer_event_body = 9;
+    SignerMigratedEventBody signer_migrated_event_body = 10;
+    IdRegisterEventBody id_register_event_body = 11;
+    StorageRentEventBody storage_rent_event_body = 12;
+  }
+  uint32 tx_index = 13;
+  uint32 version = 14;
+}
+
+enum SignerEventType {
+  SIGNER_EVENT_TYPE_NONE = 0;
+  SIGNER_EVENT_TYPE_ADD = 1;
+  SIGNER_EVENT_TYPE_REMOVE = 2;
+  SIGNER_EVENT_TYPE_ADMIN_RESET = 3;
+}
+
+message SignerEventBody {
+  bytes key = 1;
+  uint32 key_type = 2;
+  SignerEventType event_type = 3;
+  bytes metadata = 4;
+  uint32 metadata_type = 5;
+}
+
+message SignerMigratedEventBody {
+  uint32 migratedAt = 1;
+}
+
+enum IdRegisterEventType {
+  ID_REGISTER_EVENT_TYPE_NONE = 0;
+  ID_REGISTER_EVENT_TYPE_REGISTER = 1;
+  ID_REGISTER_EVENT_TYPE_TRANSFER = 2;
+  ID_REGISTER_EVENT_TYPE_CHANGE_RECOVERY = 3;
+}
+
+message IdRegisterEventBody {
+  bytes to = 1;
+  IdRegisterEventType event_type = 2;
+  bytes from = 3;
+  bytes recovery_address = 4;
+}
+
+message StorageRentEventBody {
+  bytes payer = 1;
+  uint32 units = 2;
+  uint32 expiry = 3;
 }
 
 // Fname transfers

--- a/src/proto/blocks.proto
+++ b/src/proto/blocks.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package snapchain;
 
 import "message.proto";
+import "onchain_event.proto";
 
 // Common types
 
@@ -119,72 +120,6 @@ message Transaction {
   bytes account_root = 4; // State root for the account after applying the transaction for the fid
 }
 
-enum OnChainEventType {
-  EVENT_TYPE_NONE = 0;
-  EVENT_TYPE_SIGNER = 1;
-  EVENT_TYPE_SIGNER_MIGRATED = 2;
-  EVENT_TYPE_ID_REGISTER = 3;
-  EVENT_TYPE_STORAGE_RENT = 4;
-}
-
-message OnChainEvent {
-  OnChainEventType type = 1;
-  uint32 chain_id = 2;
-  uint32 block_number = 3;
-  bytes block_hash = 4;
-  uint64 block_timestamp = 5;
-  bytes transaction_hash = 6;
-  uint32 log_index = 7;
-  uint64 fid = 8;
-  oneof body {
-    SignerEventBody signer_event_body = 9;
-    SignerMigratedEventBody signer_migrated_event_body = 10;
-    IdRegisterEventBody id_register_event_body = 11;
-    StorageRentEventBody storage_rent_event_body = 12;
-  }
-  uint32 tx_index = 13;
-  uint32 version = 14;
-}
-
-enum SignerEventType {
-  SIGNER_EVENT_TYPE_NONE = 0;
-  SIGNER_EVENT_TYPE_ADD = 1;
-  SIGNER_EVENT_TYPE_REMOVE = 2;
-  SIGNER_EVENT_TYPE_ADMIN_RESET = 3;
-}
-
-message SignerEventBody {
-  bytes key = 1;
-  uint32 key_type = 2;
-  SignerEventType event_type = 3;
-  bytes metadata = 4;
-  uint32 metadata_type = 5;
-}
-
-message SignerMigratedEventBody {
-  uint32 migratedAt = 1;
-}
-
-enum IdRegisterEventType {
-  ID_REGISTER_EVENT_TYPE_NONE = 0;
-  ID_REGISTER_EVENT_TYPE_REGISTER = 1;
-  ID_REGISTER_EVENT_TYPE_TRANSFER = 2;
-  ID_REGISTER_EVENT_TYPE_CHANGE_RECOVERY = 3;
-}
-
-message IdRegisterEventBody {
-  bytes to = 1;
-  IdRegisterEventType event_type = 2;
-  bytes from = 3;
-  bytes recovery_address = 4;
-}
-
-message StorageRentEventBody {
-  bytes payer = 1;
-  uint32 units = 2;
-  uint32 expiry = 3;
-}
-
 // Fname transfers
 message FnameTransfer {
 
@@ -192,7 +127,7 @@ message FnameTransfer {
 
 // Validator initiated prunes/revokes etc
 message ValidatorMessage {
-  OnChainEvent on_chain_event = 1;
+  onchain_event.OnChainEvent on_chain_event = 1;
   FnameTransfer fname_transfer = 2;
 }
 

--- a/src/proto/hub_event.proto
+++ b/src/proto/hub_event.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 package hub_event;
 
 import "message.proto";
-//import "onchain_event.proto";
+import "onchain_event.proto";
 import "username_proof.proto";
 
 enum HubEventType {
@@ -33,10 +33,9 @@ message RevokeMessageBody {
   msg.Message message = 1;
 }
 
-// TODO: Include once we have onchain events
-//message MergeOnChainEventBody {
-//  OnChainEvent on_chain_event = 1;
-//}
+message MergeOnChainEventBody {
+  onchain_event.OnChainEvent on_chain_event = 1;
+}
 
 message MergeUserNameProofBody {
   username_proof.UserNameProof username_proof = 1;
@@ -59,6 +58,6 @@ message HubEvent {
     //    Deprecated
     //    MergeRentRegistryEventBody merge_rent_registry_event_body = 9;
     //    MergeStorageAdminRegistryEventBody merge_storage_admin_registry_event_body = 10;
-//    MergeOnChainEventBody merge_on_chain_event_body = 11;
+    MergeOnChainEventBody merge_on_chain_event_body = 11;
   };
 }

--- a/src/proto/onchain_event.proto
+++ b/src/proto/onchain_event.proto
@@ -1,0 +1,68 @@
+syntax = "proto3";
+package onchain_event;
+
+enum OnChainEventType {
+  EVENT_TYPE_NONE = 0;
+  EVENT_TYPE_SIGNER = 1;
+  EVENT_TYPE_SIGNER_MIGRATED = 2;
+  EVENT_TYPE_ID_REGISTER = 3;
+  EVENT_TYPE_STORAGE_RENT = 4;
+}
+
+message OnChainEvent {
+  OnChainEventType type = 1;
+  uint32 chain_id = 2;
+  uint32 block_number = 3;
+  bytes block_hash = 4;
+  uint64 block_timestamp = 5;
+  bytes transaction_hash = 6;
+  uint32 log_index = 7;
+  uint64 fid = 8;
+  oneof body {
+    SignerEventBody signer_event_body = 9;
+    SignerMigratedEventBody signer_migrated_event_body = 10;
+    IdRegisterEventBody id_register_event_body = 11;
+    StorageRentEventBody storage_rent_event_body = 12;
+  }
+  uint32 tx_index = 13;
+  uint32 version = 14;
+}
+
+enum SignerEventType {
+  SIGNER_EVENT_TYPE_NONE = 0;
+  SIGNER_EVENT_TYPE_ADD = 1;
+  SIGNER_EVENT_TYPE_REMOVE = 2;
+  SIGNER_EVENT_TYPE_ADMIN_RESET = 3;
+}
+
+message SignerEventBody {
+  bytes key = 1;
+  uint32 key_type = 2;
+  SignerEventType event_type = 3;
+  bytes metadata = 4;
+  uint32 metadata_type = 5;
+}
+
+message SignerMigratedEventBody {
+  uint32 migratedAt = 1;
+}
+
+enum IdRegisterEventType {
+  ID_REGISTER_EVENT_TYPE_NONE = 0;
+  ID_REGISTER_EVENT_TYPE_REGISTER = 1;
+  ID_REGISTER_EVENT_TYPE_TRANSFER = 2;
+  ID_REGISTER_EVENT_TYPE_CHANGE_RECOVERY = 3;
+}
+
+message IdRegisterEventBody {
+  bytes to = 1;
+  IdRegisterEventType event_type = 2;
+  bytes from = 3;
+  bytes recovery_address = 4;
+}
+
+message StorageRentEventBody {
+  bytes payer = 1;
+  uint32 units = 2;
+  uint32 expiry = 3;
+}

--- a/src/storage/constants.rs
+++ b/src/storage/constants.rs
@@ -90,3 +90,11 @@ impl UserPostfix {
         self as u8
     }
 }
+pub enum OnChainEventPostfix {
+    OnChainEvents = 1,
+
+    // Secondary indexes
+    SignerByFid = 51,
+    IdRegisterByFid = 52,
+    IdRegisterByCustodyAddress = 53,
+}

--- a/src/storage/constants.rs
+++ b/src/storage/constants.rs
@@ -27,8 +27,7 @@ pub enum RootPrefix {
     // FNameUserNameProof = 11,
 
     // /* Used to store on chain events */
-    // OnChainEvent = 12,
-
+    OnChainEvent = 12,
     // /** DB Schema version */
     // DBSchemaVersion = 13,
 

--- a/src/storage/store/account/mod.rs
+++ b/src/storage/store/account/mod.rs
@@ -12,6 +12,7 @@ pub use self::store::*;
 mod cast_store;
 mod event;
 mod message;
+mod onchain_event_store;
 mod store;
 // mod link_store;
 

--- a/src/storage/store/account/mod.rs
+++ b/src/storage/store/account/mod.rs
@@ -1,6 +1,7 @@
 pub use self::cast_store::*;
 pub use self::event::*;
 pub use self::message::*;
+pub use self::onchain_event_store::*;
 pub use self::store::*;
 // pub use self::link_store::*;
 

--- a/src/storage/store/account/onchain_event_store.rs
+++ b/src/storage/store/account/onchain_event_store.rs
@@ -1,0 +1,40 @@
+use std::sync::Arc;
+
+use prost::Message;
+
+use super::make_fid_key;
+use crate::proto::snapchain::OnChainEvent;
+use crate::storage::db::{RocksDB, RocksdbError};
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum OnchainEventStorageError {
+    #[error(transparent)]
+    RocksdbError(#[from] RocksdbError),
+}
+
+pub fn put_onchain_event(
+    db: &RocksDB,
+    onchain_event: OnChainEvent,
+) -> Result<(), OnchainEventStorageError> {
+    let primary_key = make_fid_key(onchain_event.fid as u32);
+    db.put(&primary_key, &onchain_event.encode_to_vec())?;
+    Ok(())
+}
+
+pub struct OnchainEventStore {
+    db: Arc<RocksDB>,
+}
+
+impl OnchainEventStore {
+    pub fn new(db: Arc<RocksDB>) -> OnchainEventStore {
+        OnchainEventStore { db }
+    }
+
+    pub fn put_onchain_event(
+        &mut self,
+        onchain_event: OnChainEvent,
+    ) -> Result<(), OnchainEventStorageError> {
+        put_onchain_event(&self.db, onchain_event)
+    }
+}

--- a/src/storage/store/account/onchain_event_store.rs
+++ b/src/storage/store/account/onchain_event_store.rs
@@ -2,15 +2,21 @@ use std::sync::Arc;
 
 use prost::Message;
 
-use super::make_fid_key;
-use crate::proto::snapchain::OnChainEvent;
-use crate::storage::db::{RocksDB, RocksdbError};
+use super::{make_fid_key, Store, StoreEventHandler};
+use crate::core::error::HubError;
+use crate::proto::hub_event::hub_event::Body;
+use crate::proto::hub_event::{HubEvent, HubEventType, MergeOnChainEventBody};
+use crate::proto::onchain_event::OnChainEvent;
+use crate::storage::db::{RocksDB, RocksDbTransactionBatch, RocksdbError};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum OnchainEventStorageError {
     #[error(transparent)]
     RocksdbError(#[from] RocksdbError),
+
+    #[error(transparent)]
+    HubError(#[from] HubError),
 }
 
 pub fn merge_onchain_event(
@@ -24,17 +30,34 @@ pub fn merge_onchain_event(
 
 pub struct OnchainEventStore {
     db: Arc<RocksDB>,
+    store_event_handler: Arc<StoreEventHandler>,
 }
 
 impl OnchainEventStore {
-    pub fn new(db: Arc<RocksDB>) -> OnchainEventStore {
-        OnchainEventStore { db }
+    pub fn new(db: Arc<RocksDB>, store_event_handler: Arc<StoreEventHandler>) -> OnchainEventStore {
+        OnchainEventStore {
+            db,
+            store_event_handler,
+        }
     }
 
     pub fn merge_onchain_event(
         &self,
         onchain_event: OnChainEvent,
-    ) -> Result<(), OnchainEventStorageError> {
-        merge_onchain_event(&self.db, onchain_event)
+        txn: &mut RocksDbTransactionBatch,
+    ) -> Result<HubEvent, OnchainEventStorageError> {
+        merge_onchain_event(&self.db, onchain_event.clone())?;
+        let hub_event = &mut HubEvent {
+            r#type: HubEventType::MergeOnChainEvent as i32,
+            body: Some(Body::MergeOnChainEventBody(MergeOnChainEventBody {
+                on_chain_event: Some(onchain_event.clone()),
+            })),
+            id: 0,
+        };
+        let id = self
+            .store_event_handler
+            .commit_transaction(txn, hub_event)?;
+        hub_event.id = id;
+        Ok(hub_event.clone())
     }
 }

--- a/src/storage/store/account/onchain_event_store.rs
+++ b/src/storage/store/account/onchain_event_store.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use prost::Message;
 
-use super::{make_fid_key, Store, StoreEventHandler};
+use super::{make_fid_key, StoreEventHandler};
 use crate::core::error::HubError;
 use crate::proto::hub_event::hub_event::Body;
 use crate::proto::hub_event::{HubEvent, HubEventType, MergeOnChainEventBody};

--- a/src/storage/store/account/onchain_event_store.rs
+++ b/src/storage/store/account/onchain_event_store.rs
@@ -13,7 +13,7 @@ pub enum OnchainEventStorageError {
     RocksdbError(#[from] RocksdbError),
 }
 
-pub fn put_onchain_event(
+pub fn merge_onchain_event(
     db: &RocksDB,
     onchain_event: OnChainEvent,
 ) -> Result<(), OnchainEventStorageError> {
@@ -31,10 +31,10 @@ impl OnchainEventStore {
         OnchainEventStore { db }
     }
 
-    pub fn put_onchain_event(
-        &mut self,
+    pub fn merge_onchain_event(
+        &self,
         onchain_event: OnChainEvent,
     ) -> Result<(), OnchainEventStorageError> {
-        put_onchain_event(&self.db, onchain_event)
+        merge_onchain_event(&self.db, onchain_event)
     }
 }

--- a/src/storage/store/account/onchain_event_store.rs
+++ b/src/storage/store/account/onchain_event_store.rs
@@ -6,10 +6,13 @@ use super::{make_fid_key, StoreEventHandler};
 use crate::core::error::HubError;
 use crate::proto::hub_event::hub_event::Body;
 use crate::proto::hub_event::{HubEvent, HubEventType, MergeOnChainEventBody};
-use crate::proto::onchain_event::OnChainEvent;
-use crate::storage::constants::{OnChainEventPostfix, RootPrefix};
-use crate::storage::db::{RocksDB, RocksDbTransactionBatch, RocksdbError};
+use crate::proto::onchain_event::{OnChainEvent, OnChainEventType};
+use crate::storage::constants::{OnChainEventPostfix, RootPrefix, PAGE_SIZE_MAX};
+use crate::storage::db::{PageOptions, RocksDB, RocksDbTransactionBatch, RocksdbError};
+use crate::storage::util::increment_vec_u8;
 use thiserror::Error;
+
+static PAGE_SIZE: usize = 100;
 
 #[derive(Error, Debug)]
 pub enum OnchainEventStorageError {
@@ -20,6 +23,12 @@ pub enum OnchainEventStorageError {
     HubError(#[from] HubError),
 }
 
+/** A page of messages returned from various APIs */
+pub struct OnchainEventsPage {
+    pub onchain_events: Vec<OnChainEvent>,
+    pub next_page_token: Option<Vec<u8>>,
+}
+
 fn make_block_number_key(block_number: u32) -> Vec<u8> {
     block_number.to_be_bytes().to_vec()
 }
@@ -28,12 +37,16 @@ fn make_log_index_key(log_index: u32) -> Vec<u8> {
     log_index.to_be_bytes().to_vec()
 }
 
-fn make_onchain_event_primary_key(onchain_event: &OnChainEvent) -> Vec<u8> {
-    let mut primary_key = vec![
+fn make_onchain_event_type_prefix(onchain_event_type: OnChainEventType) -> Vec<u8> {
+    vec![
         RootPrefix::OnChainEvent as u8,
         OnChainEventPostfix::OnChainEvents as u8,
-        onchain_event.r#type() as u8,
-    ];
+        onchain_event_type as u8,
+    ]
+}
+
+fn make_onchain_event_primary_key(onchain_event: &OnChainEvent) -> Vec<u8> {
+    let mut primary_key = make_onchain_event_type_prefix(onchain_event.r#type());
     primary_key.extend(make_fid_key(onchain_event.fid as u32));
     primary_key.extend(make_block_number_key(onchain_event.block_number));
     primary_key.extend(make_log_index_key(onchain_event.log_index));
@@ -49,6 +62,47 @@ pub fn merge_onchain_event(
     // TODO(aditi): Incorporate secondary indices
     db.put(&primary_key, &onchain_event.encode_to_vec())?;
     Ok(())
+}
+
+pub fn get_onchain_events(
+    db: &RocksDB,
+    page_options: &PageOptions,
+    event_type: OnChainEventType,
+    fid: u32,
+) -> Result<OnchainEventsPage, OnchainEventStorageError> {
+    let mut start_prefix = make_onchain_event_type_prefix(event_type);
+    start_prefix.extend(make_fid_key(fid));
+    let stop_prefix = increment_vec_u8(&start_prefix);
+
+    let mut onchain_events = vec![];
+    let mut last_key = vec![];
+    db.for_each_iterator_by_prefix_paged(
+        Some(start_prefix),
+        Some(stop_prefix),
+        page_options,
+        |key, value| {
+            let onchain_event = OnChainEvent::decode(value).map_err(|e| HubError::from(e))?;
+            onchain_events.push(onchain_event);
+
+            if onchain_events.len() >= page_options.page_size.unwrap_or(PAGE_SIZE_MAX) {
+                last_key = key.to_vec();
+                return Ok(true); // Stop iterating
+            }
+
+            Ok(false) // Continue iterating
+        },
+    )
+    .map_err(|e| OnchainEventStorageError::HubError(e))?; // TODO: Return the right error
+    let next_page_token = if last_key.len() > 0 {
+        Some(last_key)
+    } else {
+        None
+    };
+
+    Ok(OnchainEventsPage {
+        onchain_events,
+        next_page_token,
+    })
 }
 
 pub struct OnchainEventStore {
@@ -82,5 +136,34 @@ impl OnchainEventStore {
             .commit_transaction(txn, hub_event)?;
         hub_event.id = id;
         Ok(hub_event.clone())
+    }
+
+    pub fn get_onchain_events(
+        &self,
+        event_type: OnChainEventType,
+        fid: u32,
+    ) -> Result<Vec<OnChainEvent>, OnchainEventStorageError> {
+        let mut onchain_events = vec![];
+        let mut next_page_token = None;
+        loop {
+            let onchain_events_page = get_onchain_events(
+                &self.db,
+                &PageOptions {
+                    page_size: Some(PAGE_SIZE),
+                    page_token: next_page_token,
+                    reverse: false,
+                },
+                event_type,
+                fid,
+            )?;
+            onchain_events.extend(onchain_events_page.onchain_events);
+            if onchain_events_page.next_page_token.is_none() {
+                break;
+            } else {
+                next_page_token = onchain_events_page.next_page_token
+            }
+        }
+
+        Ok(onchain_events)
     }
 }

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -99,8 +99,9 @@ impl ShardEngine {
 
         let event_handler = StoreEventHandler::new(None, None, None);
         let db = shard_store.db.clone();
-        let cast_store = CastStore::new(shard_store.db.clone(), event_handler, 100);
-        let onchain_event_store = OnchainEventStore::new(shard_store.db.clone());
+        let cast_store = CastStore::new(shard_store.db.clone(), event_handler.clone(), 100);
+        let onchain_event_store =
+            OnchainEventStore::new(shard_store.db.clone(), event_handler.clone());
 
         let (messages_tx, messages_rx) = mpsc::channel::<message::Message>(10_000);
         let (validator_message_tx, validator_message_rx) =
@@ -230,7 +231,7 @@ impl ShardEngine {
             for msg in &snap_txn.system_messages {
                 if let Some(onchain_event) = &msg.on_chain_event {
                     self.onchain_event_store
-                        .merge_onchain_event(onchain_event.clone())
+                        .merge_onchain_event(onchain_event.clone(), txn_batch)
                         .map_err(|err| EngineError::MergeOnchainEventError(err.to_string()))?;
 
                     // TODO(aditi): Insert into the trie

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -1,6 +1,8 @@
+use super::account::{OnchainEventStorageError, OnchainEventsPage};
 use super::shard::ShardStore;
 use crate::core::error::HubError;
 use crate::core::types::{proto, Height};
+use crate::proto::onchain_event::{OnChainEvent, OnChainEventType};
 use crate::proto::{msg as message, snapchain};
 use crate::storage::db;
 use crate::storage::db::{PageOptions, RocksDB, RocksDbTransactionBatch};
@@ -326,6 +328,14 @@ impl ShardEngine {
 
     pub fn get_casts_by_fid(&self, fid: u32) -> Result<MessagesPage, HubError> {
         CastStore::get_cast_adds_by_fid(&self.cast_store, fid, &PageOptions::default())
+    }
+
+    pub fn get_onchain_events(
+        &self,
+        event_type: OnChainEventType,
+        fid: u32,
+    ) -> Result<Vec<OnChainEvent>, OnchainEventStorageError> {
+        self.onchain_event_store.get_onchain_events(event_type, fid)
     }
 }
 

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -46,8 +46,8 @@ enum EngineError {
     #[error("message receive error")]
     MessageReceiveError(#[from] mpsc::error::TryRecvError),
 
-    #[error("unable to merge onchain events during commit: {0}")]
-    MergeOnchainEventError(String),
+    #[error(transparent)]
+    MergeOnchainEventError(#[from] OnchainEventStorageError),
 }
 
 impl EngineError {
@@ -253,8 +253,7 @@ impl ShardEngine {
             for msg in &snap_txn.system_messages {
                 if let Some(onchain_event) = &msg.on_chain_event {
                     self.onchain_event_store
-                        .merge_onchain_event(onchain_event.clone(), txn_batch)
-                        .map_err(|err| EngineError::MergeOnchainEventError(err.to_string()))?;
+                        .merge_onchain_event(onchain_event.clone(), txn_batch)?;
 
                     // TODO(aditi): Insert into the trie
                 }

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -312,11 +312,8 @@ async fn test_basic_consensus() {
             hash.extend_from_slice(&i.to_be_bytes()); // just for now
 
             messages_tx1
-                .send(cli::compose_message(
-                    321,
-                    format!("Cast {}", i).as_str(),
-                    None,
-                    None,
+                .send(snapchain::storage::store::engine::Message::UserMessage(
+                    cli::compose_message(321, format!("Cast {}", i).as_str(), None, None),
                 ))
                 .await
                 .unwrap();


### PR DESCRIPTION
Start storing onchain events. Onchain events still aren't plumbed through consensus, but we can manually feed them to the engine and test behavior. 