### PR TITLE
Support deletes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5153,6 +5153,7 @@ dependencies = [
  "hex",
  "humantime",
  "humantime-serde",
+ "itertools 0.13.0",
  "libp2p",
  "malachite-common",
  "malachite-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ threadpool = "1.8.1"
 rand = "0.8.5"
 humantime-serde = "1.1.1"
 humantime = "2.1.0"
+itertools = "0.13.0"
 
 [build-dependencies]
 tonic-build = "0.9.2"

--- a/src/consensus/consensus.rs
+++ b/src/consensus/consensus.rs
@@ -14,7 +14,7 @@ use malachite_consensus::{Effect, ProposedValue, Resume, SignedConsensusMsg};
 use malachite_metrics::Metrics;
 
 use crate::consensus::timers::{TimeoutElapsed, TimerScheduler};
-use crate::consensus::validator::{self, ShardValidator};
+use crate::consensus::validator::ShardValidator;
 use crate::core::types::{
     Height, ShardId, SnapchainContext, SnapchainShard, SnapchainValidator,
     SnapchainValidatorContext,

--- a/src/consensus/proposer.rs
+++ b/src/consensus/proposer.rs
@@ -294,7 +294,7 @@ impl BlockProposer {
     async fn publish_new_block(&self, block: Block) {
         match self.block_tx.send(block.clone()).await {
             Err(err) => {
-                error!("Erorr publishing new block {:#?}", err)
+                error!("Error publishing new block {:?}", err.to_string());
             }
             Ok(_) => {}
         }

--- a/src/core/message.rs
+++ b/src/core/message.rs
@@ -29,14 +29,12 @@ impl message::Message {
 
 impl snapchain::ValidatorMessage {
     pub fn fid(&self) -> u32 {
-        if self.fname_transfer.is_some() {
-            return self.fname_transfer.as_ref().unwrap().fid as u32;
+        if let Some(fname) = &self.fname_transfer {
+            return fname.fid as u32;
         }
-
-        if self.on_chain_event.is_some() {
-            return self.on_chain_event.as_ref().unwrap().fid as u32;
+        if let Some(event) = &self.on_chain_event {
+            return event.fid as u32;
         }
-
         0
     }
 }

--- a/src/core/message.rs
+++ b/src/core/message.rs
@@ -1,4 +1,5 @@
 use crate::proto::msg as message;
+use crate::proto::snapchain;
 
 impl message::Message {
     pub fn is_type(&self, message_type: message::MessageType) -> bool {
@@ -19,5 +20,23 @@ impl message::Message {
         } else {
             0
         }
+    }
+
+    pub fn hex_hash(&self) -> String {
+        hex::encode(&self.hash)
+    }
+}
+
+impl snapchain::ValidatorMessage {
+    pub fn fid(&self) -> u32 {
+        if self.fname_transfer.is_some() {
+            return self.fname_transfer.as_ref().unwrap().fid as u32;
+        }
+
+        if self.on_chain_event.is_some() {
+            return self.on_chain_event.as_ref().unwrap().fid as u32;
+        }
+
+        0
     }
 }

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -4,7 +4,7 @@ use crate::core::error::HubError;
 use crate::proto::msg as message;
 use crate::proto::rpc::snapchain_service_server::SnapchainService;
 use crate::proto::rpc::{BlocksRequest, BlocksResponse, ShardChunksRequest, ShardChunksResponse};
-use crate::storage::store::engine::Message;
+use crate::storage::store::engine::MempoolMessage;
 use crate::storage::store::shard::ShardStore;
 use crate::storage::store::BlockStore;
 use hex::ToHex;
@@ -13,7 +13,7 @@ use tonic::{Request, Response, Status};
 use tracing::info;
 
 pub struct MySnapchainService {
-    message_tx: mpsc::Sender<Message>,
+    message_tx: mpsc::Sender<MempoolMessage>,
     block_store: BlockStore,
     shard_stores: HashMap<u32, ShardStore>,
 }
@@ -22,7 +22,7 @@ impl MySnapchainService {
     pub fn new(
         block_store: BlockStore,
         shard_stores: HashMap<u32, ShardStore>,
-        message_tx: mpsc::Sender<Message>,
+        message_tx: mpsc::Sender<MempoolMessage>,
     ) -> Self {
         Self {
             block_store,
@@ -43,7 +43,7 @@ impl SnapchainService for MySnapchainService {
 
         let message = request.into_inner();
         self.message_tx
-            .send(Message::UserMessage(message.clone()))
+            .send(MempoolMessage::UserMessage(message.clone()))
             .await
             .unwrap(); // Do we need clone here? I think yes?
 

--- a/src/node/snapchain_node.rs
+++ b/src/node/snapchain_node.rs
@@ -6,10 +6,9 @@ use crate::core::types::{
     SnapchainValidatorSet,
 };
 use crate::network::gossip::GossipEvent;
-use crate::proto::msg as message;
 use crate::proto::snapchain::{Block, ShardChunk};
 use crate::storage::db::RocksDB;
-use crate::storage::store::engine::{BlockEngine, Message, ShardEngine};
+use crate::storage::store::engine::{BlockEngine, MempoolMessage, ShardEngine};
 use crate::storage::store::shard::ShardStore;
 use crate::storage::store::BlockStore;
 use libp2p::identity::ed25519::Keypair;
@@ -24,7 +23,7 @@ const MAX_SHARDS: u32 = 3;
 
 pub struct SnapchainNode {
     pub consensus_actors: BTreeMap<u32, ActorRef<ConsensusMsg<SnapchainValidatorContext>>>,
-    pub messages_tx_by_shard: HashMap<u32, mpsc::Sender<Message>>,
+    pub messages_tx_by_shard: HashMap<u32, mpsc::Sender<MempoolMessage>>,
     pub shard_stores: HashMap<u32, ShardStore>,
     pub address: Address,
 }
@@ -45,7 +44,7 @@ impl SnapchainNode {
 
         let (shard_decision_tx, shard_decision_rx) = mpsc::channel::<ShardChunk>(100);
 
-        let mut shard_messages: HashMap<u32, mpsc::Sender<Message>> = HashMap::new();
+        let mut shard_messages: HashMap<u32, mpsc::Sender<MempoolMessage>> = HashMap::new();
 
         let mut shard_stores: HashMap<u32, ShardStore> = HashMap::new();
 

--- a/src/proto/blocks.proto
+++ b/src/proto/blocks.proto
@@ -122,7 +122,7 @@ message Transaction {
 
 // Fname transfers
 message FnameTransfer {
-
+  uint64 fid = 1;
 }
 
 // Validator initiated prunes/revokes etc

--- a/src/storage/store/account/store.rs
+++ b/src/storage/store/account/store.rs
@@ -12,7 +12,6 @@ use crate::{
     proto::msg::{link_body::Target, message_data::Body, Message, MessageType},
     storage::db::{RocksDB, RocksDbTransactionBatch},
 };
-use prost::Message as _;
 use std::clone::Clone;
 use std::string::ToString;
 use std::sync::{Arc, Mutex};

--- a/src/storage/store/engine_tests.rs
+++ b/src/storage/store/engine_tests.rs
@@ -5,7 +5,7 @@ mod tests {
     use crate::proto::onchain_event::{OnChainEvent, OnChainEventType};
     use crate::proto::snapchain::{Height, ShardChunk, ShardHeader, Transaction};
     use crate::storage::db;
-    use crate::storage::store::engine::{Message, ShardEngine, ShardStateChange};
+    use crate::storage::store::engine::{MempoolMessage, ShardEngine, ShardStateChange};
     use crate::storage::store::shard::ShardStore;
     use crate::utils::cli;
     use prost::Message as _;
@@ -180,7 +180,7 @@ mod tests {
         let messages_tx = engine.messages_tx();
 
         messages_tx
-            .send(Message::UserMessage(msg1.clone()))
+            .send(MempoolMessage::UserMessage(msg1.clone()))
             .await
             .unwrap();
         let state_change = engine.propose_state_change(1);
@@ -253,7 +253,7 @@ mod tests {
 
         {
             messages_tx
-                .send(Message::UserMessage(msg1.clone()))
+                .send(MempoolMessage::UserMessage(msg1.clone()))
                 .await
                 .unwrap();
             let state_change = engine.propose_state_change(1);
@@ -282,7 +282,7 @@ mod tests {
 
         {
             messages_tx
-                .send(Message::UserMessage(msg2.clone()))
+                .send(MempoolMessage::UserMessage(msg2.clone()))
                 .await
                 .unwrap();
             let state_change = engine.propose_state_change(1);
@@ -323,11 +323,11 @@ mod tests {
 
         {
             messages_tx
-                .send(Message::UserMessage(msg1.clone()))
+                .send(MempoolMessage::UserMessage(msg1.clone()))
                 .await
                 .unwrap();
             messages_tx
-                .send(Message::UserMessage(msg2.clone()))
+                .send(MempoolMessage::UserMessage(msg2.clone()))
                 .await
                 .unwrap();
             let state_change = engine.propose_state_change(1);
@@ -364,7 +364,7 @@ mod tests {
         let (mut engine, _tmpdir) = new_engine();
         let messages_tx = engine.messages_tx();
         messages_tx
-            .send(Message::ValidatorMessage(
+            .send(MempoolMessage::ValidatorMessage(
                 crate::proto::snapchain::ValidatorMessage {
                     on_chain_event: Some(onchain_event),
                     fname_transfer: None,

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -78,12 +78,16 @@ impl NodeForTest {
         let node_id = node.id();
         let assert_valid_block = move |block: &Block| {
             let header = block.header.as_ref().unwrap();
-            let message_count = block.shard_chunks[0].transactions[0].user_messages.len();
+            let transactions_count: usize = block
+                .shard_chunks
+                .iter()
+                .map(|c| c.transactions.len())
+                .sum();
             info!(
                 hash = hex::encode(&block.hash),
                 height = header.height.as_ref().map(|h| h.block_number),
                 id = node_id,
-                message_count,
+                transactions = transactions_count,
                 "decided block",
             );
             assert_eq!(block.shard_chunks.len(), num_shards as usize);

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -312,9 +312,11 @@ async fn test_basic_consensus() {
             hash.extend_from_slice(&i.to_be_bytes()); // just for now
 
             messages_tx1
-                .send(snapchain::storage::store::engine::Message::UserMessage(
-                    cli::compose_message(321, format!("Cast {}", i).as_str(), None, None),
-                ))
+                .send(
+                    snapchain::storage::store::engine::MempoolMessage::UserMessage(
+                        cli::compose_message(321, format!("Cast {}", i).as_str(), None, None),
+                    ),
+                )
                 .await
                 .unwrap();
             i += 1;


### PR DESCRIPTION
Reflect store operations in the trie and refactor engine to create multiple transactions.

