### PR TITLE
fix message proto package name

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ pub mod proto {
     }
 
     pub mod msg {
-        tonic::include_proto!("message");
+        tonic::include_proto!("msg");
     }
 
     pub mod hub_event {


### PR DESCRIPTION
The `message` package was renamed to `msg`. Rename in `lib.rs` for the proto build. 