### PR TITLE
add logging for processing a bootstrap peer

### DIFF
--- a/src/network/gossip.rs
+++ b/src/network/gossip.rs
@@ -116,6 +116,7 @@ impl SnapchainGossip {
             .build();
 
         for addr in config.bootstrap_addrs() {
+            info!("Processing bootstrap peer: {:?}", addr);
             let parsed_addr: libp2p::Multiaddr = addr.parse()?;
             let opts = DialOpts::unknown_peer_id()
                 .address(parsed_addr.clone())


### PR DESCRIPTION
There are issues connecting to bootstrap peers. Add more logging to understand which bootstrap peer we're failing on. 