### PR TITLE
strip whitespace from bootstrap peers

### DIFF
--- a/src/network/gossip.rs
+++ b/src/network/gossip.rs
@@ -50,7 +50,7 @@ impl Config {
     pub fn bootstrap_addrs(&self) -> Vec<String> {
         self.bootstrap_peers
             .split(',')
-            .map(|s| s.to_string())
+            .map(|s| s.to_string().trim())
             .collect()
     }
 }

--- a/src/network/gossip.rs
+++ b/src/network/gossip.rs
@@ -50,7 +50,7 @@ impl Config {
     pub fn bootstrap_addrs(&self) -> Vec<String> {
         self.bootstrap_peers
             .split(',')
-            .map(|s| s.to_string().trim())
+            .map(|s| s.trim().to_string())
             .collect()
     }
 }


### PR DESCRIPTION
The config introduced a whitespace for bootstrap peers and it wouldn't parse. Change the parsing so that we can tolerate some whitespace. 