### PR TITLE
remove block channel that we don't read from

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -119,14 +119,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // Use the new non-global metrics registry when we upgrade to newer version of malachite
     let _ = Metrics::register(registry);
 
-    let (block_tx, _block_rx) = mpsc::channel::<Block>(100);
-
     let node = SnapchainNode::create(
         keypair.clone(),
         app_config.consensus.clone(),
         Some(app_config.rpc_address.clone()),
         gossip_tx.clone(),
-        block_tx,
+        None,
         block_store.clone(),
         app_config.rocksdb_dir,
     )

--- a/src/node/snapchain_node.rs
+++ b/src/node/snapchain_node.rs
@@ -34,7 +34,7 @@ impl SnapchainNode {
         config: Config,
         rpc_address: Option<String>,
         gossip_tx: mpsc::Sender<GossipEvent<SnapchainValidatorContext>>,
-        block_tx: mpsc::Sender<Block>,
+        block_tx: Option<mpsc::Sender<Block>>,
         block_store: BlockStore,
         rocksdb_dir: String,
     ) -> Self {

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -69,7 +69,7 @@ impl NodeForTest {
             config,
             None,
             gossip_tx,
-            block_tx,
+            Some(block_tx),
             block_store.clone(),
             make_tmp_path(),
         )


### PR DESCRIPTION
Nodes were halting as the block channel filled up. The fix is to not initialize the tx channel given we never read from the rx. Tested with a local 3 node setup. 