### PR TITLE
Account state roots

### DIFF
--- a/src/consensus/proposer.rs
+++ b/src/consensus/proposer.rs
@@ -76,8 +76,8 @@ impl ShardProposer {
         }
     }
 
-    async fn publish_new_shard_chunk(&self, shard_chunk: ShardChunk) {
-        &self.tx_decision.send(shard_chunk).await;
+    async fn publish_new_shard_chunk(&self, shard_chunk: &ShardChunk) {
+        &self.tx_decision.send(shard_chunk.clone()).await;
     }
 }
 
@@ -184,7 +184,7 @@ impl Proposer for ShardProposer {
                 });
                 let missing_shard_chunks = rpc_client.get_shard_chunks(request).await?;
                 for shard_chunk in missing_shard_chunks.get_ref().shard_chunks.clone() {
-                    self.engine.commit_shard_chunk(shard_chunk.clone());
+                    self.engine.commit_shard_chunk(&shard_chunk);
                 }
             }
         }

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -223,9 +223,9 @@ impl FullProposal {
         }
     }
 
-    pub fn shard_chunk(&self) -> Option<ShardChunk> {
+    pub fn shard_chunk(&self) -> Option<&ShardChunk> {
         match &self.proposed_value {
-            Some(ProposedValue::Shard(chunk)) => Some(chunk.clone()),
+            Some(ProposedValue::Shard(chunk)) => Some(&chunk),
             _ => None,
         }
     }

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -86,7 +86,7 @@ pub struct ShardEngine {
     shard_store: ShardStore,
     messages_rx: mpsc::Receiver<MempoolMessage>,
     messages_tx: mpsc::Sender<MempoolMessage>,
-    trie: merkle_trie::MerkleTrie,
+    pub(crate) trie: merkle_trie::MerkleTrie,
     cast_store: Store,
     pub db: Arc<RocksDB>,
     onchain_event_store: OnchainEventStore,
@@ -104,15 +104,8 @@ impl ShardEngine {
         let db = &*shard_store.db;
 
         // TODO: adding the trie here introduces many calls that want to return errors. Rethink unwrap strategy.
-        let mut txn_batch = RocksDbTransactionBatch::new();
         let mut trie = merkle_trie::MerkleTrie::new();
-        trie.initialize(db, &mut txn_batch).unwrap();
-
-        // TODO: The empty trie currently has some issues with the newly added commit/rollback code. Remove when we can.
-        trie.insert(db, &mut txn_batch, vec![vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9]])
-            .unwrap();
-        db.commit(txn_batch).unwrap();
-        trie.reload(db).unwrap();
+        trie.initialize(db).unwrap();
 
         let event_handler = StoreEventHandler::new(None, None, None);
         let db = shard_store.db.clone();

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -304,6 +304,10 @@ impl ShardEngine {
                 .cast_store
                 .merge(msg, txn_batch)
                 .map_err(EngineError::new_store_error(msg.hash.clone())),
+            MessageType::CastRemove => self
+                .cast_store
+                .merge(msg, txn_batch)
+                .map_err(EngineError::new_store_error(msg.hash.clone())),
             unhandled_type => {
                 return Err(EngineError::UnsupportedMessageType(unhandled_type));
             }
@@ -362,7 +366,7 @@ impl ShardEngine {
         result
     }
 
-    pub fn commit_shard_chunk(&mut self, shard_chunk: ShardChunk) {
+    pub fn commit_shard_chunk(&mut self, shard_chunk: &ShardChunk) {
         let mut txn = RocksDbTransactionBatch::new();
 
         let shard_root = &shard_chunk.header.as_ref().unwrap().shard_root;

--- a/src/storage/store/shard.rs
+++ b/src/storage/store/shard.rs
@@ -132,7 +132,7 @@ pub fn get_current_height(db: &RocksDB) -> Result<Option<u64>, ShardStorageError
     }
 }
 
-pub fn put_shard_chunk(db: &RocksDB, shard_chunk: ShardChunk) -> Result<(), ShardStorageError> {
+pub fn put_shard_chunk(db: &RocksDB, shard_chunk: &ShardChunk) -> Result<(), ShardStorageError> {
     // TODO: We need to introduce a transaction model
     let header = shard_chunk
         .header
@@ -169,7 +169,7 @@ impl ShardStore {
         ShardStore { db: Arc::new(db) }
     }
 
-    pub fn put_shard_chunk(&self, shard_chunk: ShardChunk) -> Result<(), ShardStorageError> {
+    pub fn put_shard_chunk(&self, shard_chunk: &ShardChunk) -> Result<(), ShardStorageError> {
         put_shard_chunk(&self.db, shard_chunk)
     }
 

--- a/src/storage/trie/commit_rollback_tests.rs
+++ b/src/storage/trie/commit_rollback_tests.rs
@@ -28,9 +28,9 @@ mod tests {
         let db = &RocksDB::new(db_path.to_str().unwrap());
         db.open().unwrap();
 
-        let mut txn_batch = RocksDbTransactionBatch::new();
-        t.initialize(db, &mut txn_batch)?;
+        t.initialize(db)?;
 
+        let mut txn_batch = RocksDbTransactionBatch::new();
         t.insert(
             db,
             &mut txn_batch,
@@ -86,9 +86,9 @@ mod tests {
             db.open().unwrap();
 
             let mut t1 = MerkleTrie::new();
-            let mut txn_batch = RocksDbTransactionBatch::new();
+            t1.initialize(db)?;
 
-            t1.initialize(db, &mut txn_batch)?;
+            let mut txn_batch = RocksDbTransactionBatch::new();
             t1.insert(db, &mut txn_batch, hashes1.clone())?;
             let items = t1.items()?;
             println!(
@@ -104,9 +104,9 @@ mod tests {
             db.open().unwrap();
 
             let mut t2 = MerkleTrie::new();
-            let mut txn_batch = RocksDbTransactionBatch::new();
+            t2.initialize(db)?;
 
-            t2.initialize(db, &mut txn_batch)?;
+            let mut txn_batch = RocksDbTransactionBatch::new();
             t2.insert(db, &mut txn_batch, hashes1)?;
             let items = t2.items()?;
             println!(

--- a/src/utils/factory.rs
+++ b/src/utils/factory.rs
@@ -1,0 +1,112 @@
+use crate::core::types::FARCASTER_EPOCH;
+use crate::proto::msg as message;
+use ed25519_dalek::{SecretKey, Signer, SigningKey};
+use hex::FromHex;
+use message::CastType::Cast;
+use message::MessageType;
+use message::{CastAddBody, FarcasterNetwork, MessageData};
+use prost::Message;
+
+pub mod messages_factory {
+    use super::*;
+
+    pub fn farcaster_time() -> u32 {
+        (std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            - FARCASTER_EPOCH) as u32
+    }
+
+    pub fn create_message_with_data(
+        fid: u32,
+        body: message::message_data::Body,
+        timestamp: Option<u32>,
+        private_key: Option<SigningKey>,
+    ) -> message::Message {
+        let key = private_key.unwrap_or_else(|| {
+            SigningKey::from_bytes(
+                &SecretKey::from_hex(
+                    "1000000000000000000000000000000000000000000000000000000000000000",
+                )
+                .unwrap(),
+            )
+        });
+        let network = FarcasterNetwork::Mainnet;
+
+        let timestamp = timestamp.unwrap_or_else(|| farcaster_time());
+
+        let msg_type = match &body {
+            message::message_data::Body::CastAddBody(_) => MessageType::CastAdd,
+            message::message_data::Body::CastRemoveBody(_) => MessageType::CastRemove,
+            _ => panic!("Invalid message type"),
+        };
+
+        let msg_data = MessageData {
+            fid: fid as u64,
+            r#type: msg_type as i32,
+            timestamp,
+            network: network as i32,
+            body: Some(body),
+        };
+
+        let msg_data_bytes = msg_data.encode_to_vec();
+        let hash = blake3::hash(&msg_data_bytes).as_bytes()[0..20].to_vec();
+
+        let signature = key.sign(&hash).to_bytes();
+        message::Message {
+            data: Some(msg_data),
+            hash_scheme: message::HashScheme::Blake3 as i32,
+            hash: hash.clone(),
+            signature_scheme: message::SignatureScheme::Ed25519 as i32,
+            signature: signature.to_vec(),
+            signer: key.verifying_key().to_bytes().to_vec(),
+            data_bytes: None,
+        }
+    }
+
+    pub mod casts {
+        use super::*;
+        use crate::proto::msg::CastRemoveBody;
+
+        pub fn create_cast_add(
+            fid: u32,
+            text: &str,
+            timestamp: Option<u32>,
+            private_key: Option<SigningKey>,
+        ) -> message::Message {
+            let cast_add = CastAddBody {
+                text: text.to_string(),
+                embeds: vec![],
+                embeds_deprecated: vec![],
+                mentions: vec![],
+                mentions_positions: vec![],
+                parent: None,
+                r#type: Cast as i32,
+            };
+            create_message_with_data(
+                fid,
+                message::message_data::Body::CastAddBody(cast_add),
+                timestamp,
+                private_key,
+            )
+        }
+
+        pub fn create_cast_remove(
+            fid: u32,
+            target_hash: &Vec<u8>,
+            timestamp: Option<u32>,
+            private_key: Option<SigningKey>,
+        ) -> crate::proto::msg::Message {
+            let cast_remove = CastRemoveBody {
+                target_hash: target_hash.clone(),
+            };
+            create_message_with_data(
+                fid,
+                message::message_data::Body::CastRemoveBody(cast_remove),
+                timestamp,
+                private_key,
+            )
+        }
+    }
+}

--- a/src/utils/factory.rs
+++ b/src/utils/factory.rs
@@ -1,11 +1,32 @@
 use crate::core::types::FARCASTER_EPOCH;
 use crate::proto::msg as message;
+use crate::proto::onchain_event::{OnChainEvent, OnChainEventType};
 use ed25519_dalek::{SecretKey, Signer, SigningKey};
 use hex::FromHex;
 use message::CastType::Cast;
 use message::MessageType;
 use message::{CastAddBody, FarcasterNetwork, MessageData};
 use prost::Message;
+
+pub mod events_factory {
+    use super::*;
+
+    pub fn create_onchain_event(fid: u32) -> OnChainEvent {
+        OnChainEvent {
+            r#type: OnChainEventType::EventTypeIdRegister as i32,
+            chain_id: 10,
+            block_number: rand::random::<u32>(),
+            block_hash: vec![],
+            block_timestamp: 0,
+            transaction_hash: rand::random::<[u8; 32]>().to_vec(),
+            log_index: 0,
+            fid: fid as u64,
+            tx_index: 0,
+            version: 1,
+            body: None,
+        }
+    }
+}
 
 pub mod messages_factory {
     use super::*;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,1 +1,2 @@
 pub mod cli;
+pub mod factory;


### PR DESCRIPTION
Insert messages into the trie using the correct prefixes so we now have account specific state roots.

Also added more tests, and fixed reloading an empty trie