### PR TITLE
read persisted events from db for event stream

### DIFF
--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -171,8 +171,9 @@ impl SnapchainService for MySnapchainService {
                 .unwrap();
 
                 for event in old_events.events {
-                    // TODO(aditi): Fix error handling
-                    server_tx.send(Ok(event)).await.unwrap();
+                    if let Err(err) = server_tx.send(Ok(event)).await {
+                        return Err(Status::from_error(Box::new(err)));
+                    }
                 }
 
                 page_token = old_events.next_page_token;

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use crate::core::error::HubError;
 use crate::proto::hub_event::HubEvent;
@@ -7,7 +8,8 @@ use crate::proto::rpc::snapchain_service_server::SnapchainService;
 use crate::proto::rpc::{
     BlocksRequest, BlocksResponse, ShardChunksRequest, ShardChunksResponse, SubscribeRequest,
 };
-use crate::storage::store::engine::MempoolMessage;
+use crate::storage::db::{PageOptions, RocksDB};
+use crate::storage::store::engine::{MempoolMessage, Senders, Stores};
 use crate::storage::store::shard::ShardStore;
 use crate::storage::store::BlockStore;
 use alloy::rpc::types::request;
@@ -21,23 +23,25 @@ use tonic::{server, Request, Response, Status};
 use tracing::info;
 
 pub struct MySnapchainService {
-    message_tx: mpsc::Sender<MempoolMessage>,
     block_store: BlockStore,
-    shard_stores: HashMap<u32, ShardStore>,
-    shard_events: HashMap<u32, broadcast::Sender<HubEvent>>,
+    shard_stores: HashMap<u32, Stores>,
+    shard_senders: HashMap<u32, Senders>,
+    message_tx: mpsc::Sender<MempoolMessage>,
 }
 
 impl MySnapchainService {
     pub fn new(
         block_store: BlockStore,
-        shard_stores: HashMap<u32, ShardStore>,
-        shard_events: HashMap<u32, broadcast::Sender<HubEvent>>,
-        message_tx: mpsc::Sender<MempoolMessage>,
+        shard_stores: HashMap<u32, Stores>,
+        shard_senders: HashMap<u32, Senders>,
     ) -> Self {
+        // TODO(aditi): This logic will change once a mempool exists
+        let message_tx = shard_senders.get(&1u32).unwrap().messages_tx.clone();
+
         Self {
             block_store,
+            shard_senders,
             shard_stores,
-            shard_events,
             message_tx,
         }
     }
@@ -54,6 +58,7 @@ impl SnapchainService for MySnapchainService {
         info!(hash, "Received call to [submit_message] RPC");
 
         let message = request.into_inner();
+
         self.message_tx
             .send(MempoolMessage::UserMessage(message.clone()))
             .await
@@ -96,13 +101,16 @@ impl SnapchainService for MySnapchainService {
         info!( {shard_index, start_block_number, stop_block_number},
             "Received call to [get_shard_chunks] RPC");
 
-        let shard_store = self.shard_stores.get(&shard_index);
-        match shard_store {
+        let stores = self.shard_stores.get(&shard_index);
+        match stores {
             None => Err(Status::from_error(Box::new(
                 HubError::invalid_internal_state("Missing shard store"),
             ))),
-            Some(shard_store) => {
-                match shard_store.get_shard_chunks(start_block_number, stop_block_number) {
+            Some(stores) => {
+                match stores
+                    .shard_store
+                    .get_shard_chunks(start_block_number, stop_block_number)
+                {
                     Err(err) => Err(Status::from_error(Box::new(err))),
                     Ok(shard_chunks) => {
                         let response = Response::new(ShardChunksResponse { shard_chunks });
@@ -119,22 +127,61 @@ impl SnapchainService for MySnapchainService {
         &self,
         request: Request<SubscribeRequest>,
     ) -> Result<Response<Self::SubscribeStream>, Status> {
-        // TODO(aditi): Use [from_id]
-        // TODO(aditi): Read older events from the db
         // TODO(aditi): Rethink the channel size
         let (server_tx, client_rx) = mpsc::channel::<Result<HubEvent, Status>>(100);
         let events_txs = match request.get_ref().shard_index {
-            Some(shard_id) => match self.shard_events.get(&(shard_id as u32)) {
+            Some(shard_id) => match self.shard_senders.get(&(shard_id as u32)) {
                 None => {
                     return Err(Status::from_error(Box::new(
                         HubError::invalid_internal_state("Missing shard event tx"),
                     )))
                 }
-                Some(tx) => vec![tx.clone()],
+                Some(senders) => vec![senders.events_tx.clone()],
             },
-            None => self.shard_events.values().cloned().collect(),
+            None => self
+                .shard_senders
+                .values()
+                .map(|senders| senders.events_tx.clone())
+                .collect(),
         };
 
+        let shard_stores = match request.get_ref().shard_index {
+            Some(shard_id) => {
+                vec![self.shard_stores.get(&shard_id).unwrap()]
+            }
+            None => self.shard_stores.values().collect(),
+        };
+
+        let start_id = request.get_ref().from_id.unwrap_or(0);
+
+        let mut page_token = None;
+        for store in shard_stores {
+            loop {
+                let old_events = HubEvent::get_events(
+                    store.shard_store.db.clone(),
+                    start_id,
+                    None,
+                    Some(PageOptions {
+                        page_token: page_token.clone(),
+                        page_size: None,
+                        reverse: false,
+                    }),
+                )
+                .unwrap();
+
+                for event in old_events.events {
+                    // TODO(aditi): Fix error handling
+                    server_tx.send(Ok(event)).await.unwrap();
+                }
+
+                page_token = old_events.next_page_token;
+                if page_token.is_none() {
+                    break;
+                }
+            }
+        }
+
+        // TODO(aditi): It's possible that events show up between when we finish reading from the db and the subscription starts. We don't handle this case in the current hub code, but we may want to down the line.
         for event_tx in events_txs {
             let tx = server_tx.clone();
             tokio::spawn(async move {

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -157,6 +157,7 @@ impl SnapchainService for MySnapchainService {
         let mut page_token = None;
         for store in shard_stores {
             loop {
+                // TODO(aditi): We should stop pulling the raw db out of the shard store and create a new store type for events to house the db.
                 let old_events = HubEvent::get_events(
                     store.shard_store.db.clone(),
                     start_id,

--- a/src/storage/store/account/cast_store.rs
+++ b/src/storage/store/account/cast_store.rs
@@ -44,6 +44,7 @@ type Parent = message::cast_add_body::Parent;
  * 4. parentFid:parentTsHash:fid:tsHash -> fid:tsHash (Child Set Index)
  * 5. mentionFid:fid:tsHash -> fid:tsHash (Mentions Set Index)
  */
+#[derive(Clone)]
 pub struct CastStoreDef {
     prune_size_limit: u32,
 }
@@ -365,16 +366,12 @@ impl CastStore {
         db: Arc<RocksDB>,
         store_event_handler: Arc<StoreEventHandler>,
         prune_size_limit: u32,
-    ) -> Store {
-        Store::new_with_store_def(
-            db,
-            store_event_handler,
-            Box::new(CastStoreDef { prune_size_limit }),
-        )
+    ) -> Store<CastStoreDef> {
+        Store::new_with_store_def(db, store_event_handler, CastStoreDef { prune_size_limit })
     }
 
     pub fn get_cast_add(
-        store: &Store,
+        store: &Store<CastStoreDef>,
         fid: u32,
         hash: Vec<u8>,
     ) -> Result<Option<Message>, HubError> {
@@ -397,7 +394,7 @@ impl CastStore {
     }
 
     pub fn get_cast_remove(
-        store: &Store,
+        store: &Store<CastStoreDef>,
         fid: u32,
         hash: Vec<u8>,
     ) -> Result<Option<Message>, HubError> {
@@ -419,7 +416,7 @@ impl CastStore {
     }
 
     pub fn get_cast_adds_by_fid(
-        store: &Store,
+        store: &Store<CastStoreDef>,
         fid: u32,
         page_options: &PageOptions,
     ) -> Result<MessagesPage, HubError> {
@@ -427,7 +424,7 @@ impl CastStore {
     }
 
     pub fn get_cast_removes_by_fid(
-        store: &Store,
+        store: &Store<CastStoreDef>,
         fid: u32,
         page_options: &PageOptions,
     ) -> Result<MessagesPage, HubError> {
@@ -435,7 +432,7 @@ impl CastStore {
     }
 
     pub fn get_casts_by_parent(
-        store: &Store,
+        store: &Store<CastStoreDef>,
         parent: &Parent,
         page_options: &PageOptions,
     ) -> Result<MessagesPage, HubError> {
@@ -483,7 +480,7 @@ impl CastStore {
     }
 
     pub fn get_casts_by_mention(
-        store: &Store,
+        store: &Store<CastStoreDef>,
         mention: u32,
         page_options: &PageOptions,
     ) -> Result<MessagesPage, HubError> {

--- a/src/storage/store/account/onchain_event_store.rs
+++ b/src/storage/store/account/onchain_event_store.rs
@@ -105,6 +105,7 @@ pub fn get_onchain_events(
     })
 }
 
+#[derive(Clone)]
 pub struct OnchainEventStore {
     db: Arc<RocksDB>,
     store_event_handler: Arc<StoreEventHandler>,

--- a/src/storage/store/account/store.rs
+++ b/src/storage/store/account/store.rs
@@ -280,19 +280,23 @@ pub trait StoreDef: Send + Sync {
     // }
 }
 
-pub struct Store {
-    store_def: Box<dyn StoreDef>,
+#[derive(Clone)]
+pub struct Store<T>
+where
+    T: StoreDef + Clone,
+{
+    store_def: T,
     store_event_handler: Arc<StoreEventHandler>,
     fid_locks: Arc<[Mutex<()>; 4]>,
     db: Arc<RocksDB>,
 }
 
-impl Store {
+impl<T: StoreDef + Clone> Store<T> {
     pub fn new_with_store_def(
         db: Arc<RocksDB>,
         store_event_handler: Arc<StoreEventHandler>,
-        store_def: Box<dyn StoreDef>,
-    ) -> Store {
+        store_def: T,
+    ) -> Store<T> {
         Store {
             store_def,
             store_event_handler,
@@ -306,8 +310,8 @@ impl Store {
         }
     }
 
-    pub fn store_def(&self) -> &dyn StoreDef {
-        self.store_def.as_ref()
+    pub fn store_def(&self) -> T {
+        self.store_def.clone()
     }
 
     pub fn db(&self) -> Arc<RocksDB> {
@@ -962,4 +966,4 @@ impl Store {
 // Note about dispatch - The methods are dispatched to the Store struct, which is a Box<dyn StoreDef>.
 // This means the NodeJS code can pass in any store, and the Rust code will call the correct method
 // for that store
-impl Store {}
+impl<T: StoreDef + Clone> Store<T> {}

--- a/src/storage/store/shard.rs
+++ b/src/storage/store/shard.rs
@@ -165,8 +165,8 @@ pub struct ShardStore {
 }
 
 impl ShardStore {
-    pub fn new(db: RocksDB) -> ShardStore {
-        ShardStore { db: Arc::new(db) }
+    pub fn new(db: Arc<RocksDB>) -> ShardStore {
+        ShardStore { db }
     }
 
     pub fn put_shard_chunk(&self, shard_chunk: &ShardChunk) -> Result<(), ShardStorageError> {

--- a/src/storage/trie/merkle_trie.rs
+++ b/src/storage/trie/merkle_trie.rs
@@ -48,6 +48,7 @@ pub struct TrieSnapshot {
     pub num_messages: usize,
 }
 
+#[derive(Clone)]
 pub struct MerkleTrie {
     root: Option<TrieNode>,
 }


### PR DESCRIPTION
Add support for reading from the db in the event stream. 

Along with this, I refactored the way we deal with stores and channels in the engine. We started creating a bunch of ad-hoc maps to feed data in the engine to the rpc server. Refactored this to pull out all the stores/channel senders together. 