### PR TITLE
add an optional start timestamp to the rpc to get blocks

### DIFF
--- a/src/consensus/proposer.rs
+++ b/src/consensus/proposer.rs
@@ -389,9 +389,9 @@ impl Proposer for BlockProposer {
                 let destination_addr = format!("http://{}", rpc_address.clone());
                 let mut rpc_client = SnapchainServiceClient::connect(destination_addr).await?;
                 let request = Request::new(BlocksRequest {
-                    shard_id: self.shard_id.shard_id(),
                     start_block_number: prev_block_number + 1,
                     stop_block_number: None,
+                    start_timestamp: None,
                 });
                 let missing_blocks = rpc_client.get_blocks(request).await?;
                 for block in missing_blocks.get_ref().blocks.clone() {

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -69,6 +69,7 @@ impl SnapchainService for MySnapchainService {
     ) -> Result<Response<BlocksResponse>, Status> {
         let start_block_number = request.get_ref().start_block_number;
         let stop_block_number = request.get_ref().stop_block_number;
+        let start_timestamp = request.get_ref().start_timestamp;
 
         info!( {start_block_number, stop_block_number}, "Received call to [get_blocks] RPC");
 
@@ -78,6 +79,13 @@ impl SnapchainService for MySnapchainService {
         {
             Err(err) => Err(Status::from_error(Box::new(err))),
             Ok(blocks) => {
+                let blocks = match start_timestamp {
+                    None => blocks,
+                    Some(start_timestamp) => blocks
+                        .into_iter()
+                        .filter(|block| block.header.as_ref().unwrap().timestamp >= start_timestamp)
+                        .collect(),
+                };
                 let response = Response::new(BlocksResponse { blocks });
                 Ok(response)
             }

--- a/src/proto/rpc.proto
+++ b/src/proto/rpc.proto
@@ -6,9 +6,9 @@ import "blocks.proto";
 import "hub_event.proto";
 
 message BlocksRequest {
-  uint32 shard_id = 1;
-  uint64 start_block_number = 2;
-  optional uint64 stop_block_number = 3;
+  uint64 start_block_number = 1;
+  optional uint64 stop_block_number = 2;
+  optional uint64 start_timestamp = 3;
 }
 
 message BlocksResponse {

--- a/src/utils/cli.rs
+++ b/src/utils/cli.rs
@@ -1,3 +1,4 @@
+use crate::consensus::proposer::current_time;
 use crate::proto::msg as message;
 use crate::proto::rpc::snapchain_service_client::SnapchainServiceClient;
 use crate::proto::{rpc, snapchain::Block};
@@ -41,9 +42,9 @@ pub async fn follow_blocks(
 
     loop {
         let msg = rpc::BlocksRequest {
-            shard_id: 0,
             start_block_number: i,
             stop_block_number: Some(i + FETCH_SIZE),
+            start_timestamp: Some(current_time()),
         };
 
         let request = tonic::Request::new(msg);


### PR DESCRIPTION
In the follow blocks script, we end up getting all the blocks from the beginning up to the latest when what we really wanna do is see the blocks minted starting from the time when we run the script. Add an optional start timestamp parameter to the `GetBlocks` request to support this. 