### PR TITLE
fixes for perf test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,7 @@ COPY --from=builder \
     /usr/src/app/target/release/follow_blocks \
     /usr/src/app/target/release/setup_local_testnet \
     /usr/src/app/target/release/submit_message \
+    /usr/src/app/target/release/perftest \
     /app/
 
 ENV RUSTFLAGS="-Awarnings"

--- a/src/bin/statsd_printer.rs
+++ b/src/bin/statsd_printer.rs
@@ -1,0 +1,62 @@
+use clap::Parser;
+use std::collections::HashSet;
+use std::net::UdpSocket;
+
+/// A simple StatsD UDP listener and parser
+#[derive(Parser)]
+struct Args {
+    /// Don't print metric values
+    #[arg(long)]
+    no_values: bool,
+
+    /// Print each metric name and type only once
+    #[arg(long)]
+    unique: bool,
+}
+
+fn parse_and_print_metric(
+    metric: &str,
+    name_only: bool,
+    unique: bool,
+    seen_metrics: &mut HashSet<(String, String)>,
+) {
+    let parts: Vec<&str> = metric.split([':', '|']).collect();
+    if parts.len() >= 3 {
+        let name = parts[0].to_string();
+        let metric_type = parts[2].to_string();
+
+        if unique {
+            if seen_metrics.contains(&(name.clone(), metric_type.clone())) {
+                return;
+            }
+            seen_metrics.insert((name.clone(), metric_type.clone()));
+        }
+
+        let value = parts[1];
+
+        if name_only {
+            println!("{:<2} {}", metric_type, name);
+        } else {
+            println!("{:<2} {:>10} {}", metric_type, value, name);
+        }
+    }
+}
+
+fn main() {
+    let args = Args::parse();
+    let socket = UdpSocket::bind("0.0.0.0:8125").unwrap();
+    let mut buf = vec![0u8; 65536];
+    let mut seen_metrics = HashSet::new();
+
+    loop {
+        let (size, _) = socket.recv_from(&mut buf).unwrap();
+        let data = &buf[..size];
+        let message = String::from_utf8_lossy(data);
+
+        for line in message.lines() {
+            if !line.trim().is_empty() {
+                parse_and_print_metric(line, args.no_values, args.unique, &mut seen_metrics);
+            }
+        }
+    }
+}

--- a/src/bin/submit_message.rs
+++ b/src/bin/submit_message.rs
@@ -24,10 +24,12 @@ async fn main() {
 
     let mut client = SnapchainServiceClient::connect(args.addr).await.unwrap();
 
-    send_message(
+    let resp = send_message(
         &mut client,
         &compose_message(6833, "Welcome from Rust!", None, Some(private_key)),
     )
     .await
     .unwrap();
+
+    println!("response: {:?}", resp);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,7 +160,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let rpc_block_store = block_store.clone();
     tokio::spawn(async move {
-        let service = MySnapchainService::new(rpc_block_store, rpc_shard_stores, rpc_shard_senders);
+        let service = MySnapchainService::new(
+            rpc_block_store,
+            rpc_shard_stores,
+            rpc_shard_senders,
+            statsd_client.clone(),
+        );
 
         let resp = Server::builder()
             .add_service(SnapchainServiceServer::new(service))

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -11,6 +11,7 @@ mod tests {
     use crate::storage::db::{self, RocksDB, RocksDbTransactionBatch};
     use crate::storage::store::engine::{Senders, Stores};
     use crate::storage::store::BlockStore;
+    use crate::utils::statsd_wrapper::StatsdClientWrapper;
     use futures::StreamExt;
     use tempfile;
     use tokio::sync::{broadcast, mpsc};
@@ -88,6 +89,11 @@ mod tests {
         HashMap<u32, Senders>,
         MySnapchainService,
     ) {
+        let statsd_client = StatsdClientWrapper::new(
+            cadence::StatsdClient::builder("", cadence::NopMetricSink {}).build(),
+            true,
+        );
+
         let db1 = make_db("b1.db");
         let db2 = make_db("b2.db");
 
@@ -104,7 +110,12 @@ mod tests {
         (
             stores.clone(),
             senders.clone(),
-            MySnapchainService::new(BlockStore::new(make_db("blocks.db")), stores, senders),
+            MySnapchainService::new(
+                BlockStore::new(make_db("blocks.db")),
+                stores,
+                senders,
+                statsd_client,
+            ),
         )
     }
 

--- a/src/utils/statsd_wrapper.rs
+++ b/src/utils/statsd_wrapper.rs
@@ -1,4 +1,4 @@
-use cadence::{Counted, CountedExt, Gauged, StatsdClient};
+use cadence::{Counted, Gauged, StatsdClient, Timed};
 use std::sync::Arc;
 
 pub struct StatsdClientWrapper {
@@ -53,5 +53,9 @@ impl StatsdClientWrapper {
 
     pub fn gauge(&self, key: &str, value: u64) {
         _ = self.client.gauge(key, value)
+    }
+
+    pub fn time(&self, key: &str, value: u64) {
+        _ = self.client.time(key, value)
     }
 }

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -78,7 +78,7 @@ impl NodeForTest {
             Some(block_tx),
             block_store.clone(),
             make_tmp_path(),
-            statsd_client,
+            statsd_client.clone(),
         )
         .await;
 

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -112,8 +112,12 @@ impl NodeForTest {
         let grpc_shard_stores = node.shard_stores.clone();
         let grpc_shard_senders = node.shard_senders.clone();
         tokio::spawn(async move {
-            let service =
-                MySnapchainService::new(grpc_block_store, grpc_shard_stores, grpc_shard_senders);
+            let service = MySnapchainService::new(
+                grpc_block_store,
+                grpc_shard_stores,
+                grpc_shard_senders,
+                statsd_client.clone(),
+            );
 
             let grpc_socket_addr: SocketAddr = addr.parse().unwrap();
             let resp = Server::builder()


### PR DESCRIPTION
This PR does a few things:

- rename `collect_stats` to `pertest`
- add a panic handler to perftest so it exits if any thread panics
- add a `statsd_printer` script that can listen to UDP 8125 to print metric names for debugging
- add stats for grpc submit_message
- add and refactor engine stats
- a few misc fixes

New metrics come out with keys looking like these:

```
c  snapchain1.rpc.submit_message.success
c  snapchain1.shard1.engine.commit.invoked
c  snapchain1.shard1.engine.commit.system_messages
c  snapchain1.shard1.engine.commit.transactions
c  snapchain1.shard1.engine.commit.user_messages
c  snapchain1.shard1.engine.prepare_proposal.recv_messages
c  snapchain1.shard1.engine.prepare_proposal.system_messages
c  snapchain1.shard1.engine.prepare_proposal.transactions
c  snapchain1.shard1.engine.prepare_proposal.user_messages
c  snapchain1.shard1.engine.propose.invoked
c  snapchain1.shard1.engine.validate.false
c  snapchain1.shard1.engine.validate.true
g  snapchain1.shard1.engine.block_height
g  snapchain1.shard1.engine.trie.num_items
ms snapchain1.rpc.submit_message.duration
```