### PR TITLE
implement get blocks as streaming rpc

### DIFF
--- a/src/proto/rpc.proto
+++ b/src/proto/rpc.proto
@@ -11,10 +11,6 @@ message BlocksRequest {
   optional uint64 stop_block_number = 3;
 }
 
-message BlocksResponse {
-  repeated snapchain.Block blocks = 1;
-}
-
 message ShardChunksRequest {
   uint32 shard_id = 1;
   uint64 start_block_number = 2;
@@ -35,7 +31,7 @@ message SubscribeRequest {
 
 service SnapchainService {
   rpc SubmitMessage(msg.Message) returns (msg.Message);
-  rpc GetBlocks(BlocksRequest) returns (BlocksResponse);
+  rpc GetBlocks(BlocksRequest) returns (stream snapchain.Block);
   rpc GetShardChunks(ShardChunksRequest) returns (ShardChunksResponse);
   rpc Subscribe(SubscribeRequest) returns (stream hub_event.HubEvent);
 };

--- a/src/storage/store/block.rs
+++ b/src/storage/store/block.rs
@@ -185,28 +185,13 @@ impl BlockStore {
         &self,
         start_block_number: u64,
         stop_block_number: Option<u64>,
-    ) -> Result<Vec<Block>, BlockStorageError> {
-        let mut blocks = vec![];
-        let mut next_page_token = None;
-        loop {
-            let block_page = get_blocks_in_range(
-                &self.db,
-                &PageOptions {
-                    page_size: Some(PAGE_SIZE),
-                    page_token: next_page_token,
-                    reverse: false,
-                },
-                start_block_number,
-                stop_block_number,
-            )?;
-            blocks.extend(block_page.blocks);
-            if block_page.next_page_token.is_none() {
-                break;
-            } else {
-                next_page_token = block_page.next_page_token
-            }
-        }
-
-        Ok(blocks)
+        page_options: &PageOptions,
+    ) -> Result<BlockPage, BlockStorageError> {
+        get_blocks_in_range(
+            &self.db,
+            page_options,
+            start_block_number,
+            stop_block_number,
+        )
     }
 }

--- a/src/utils/cli.rs
+++ b/src/utils/cli.rs
@@ -47,17 +47,12 @@ pub async fn follow_blocks(
         };
 
         let request = tonic::Request::new(msg);
-        let response = client.get_blocks(request).await?;
-
-        let inner = response.into_inner();
-        if inner.blocks.is_empty() {
-            time::sleep(time::Duration::from_millis(10)).await;
-            continue;
-        }
-
-        for block in &inner.blocks {
+        let mut response = client.get_blocks(request).await?.into_inner();
+        while let Ok(Some(block)) = response.message().await {
             block_tx.send(block.clone()).await.unwrap();
             i += 1;
         }
+
+        time::sleep(time::Duration::from_millis(10)).await;
     }
 }

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -8,7 +8,7 @@ use snapchain::network::server::MySnapchainService;
 use snapchain::node::snapchain_node::SnapchainNode;
 use snapchain::proto::rpc::snapchain_service_server::SnapchainServiceServer;
 use snapchain::proto::snapchain::Block;
-use snapchain::storage::db::RocksDB;
+use snapchain::storage::db::{PageOptions, RocksDB};
 use snapchain::storage::store::BlockStore;
 use snapchain::utils::cli;
 use snapchain::utils::statsd_wrapper::StatsdClientWrapper;
@@ -170,8 +170,11 @@ impl NodeForTest {
     }
 
     pub async fn num_blocks(&self) -> usize {
-        let blocks = self.block_store.get_blocks(0, None).unwrap();
-        blocks.len()
+        let blocks_page = self
+            .block_store
+            .get_blocks(0, None, &PageOptions::default())
+            .unwrap();
+        blocks_page.blocks.len()
     }
 
     pub async fn num_shard_chunks(&self) -> usize {
@@ -186,8 +189,9 @@ impl NodeForTest {
     pub async fn total_messages(&self) -> usize {
         let messages = self
             .block_store
-            .get_blocks(0, None)
+            .get_blocks(0, None, &PageOptions::default())
             .unwrap()
+            .blocks
             .into_iter()
             .map(|b| b.shard_chunks[0].transactions[0].user_messages.len());
 


### PR DESCRIPTION
Implement get blocks as a streaming rpc to fix some of the usability issues. 