### PR TITLE
Fix trie key collision for onchain events and message types

### DIFF
--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -412,7 +412,12 @@ impl ShardEngine {
                     }
                 }
                 Err(err) => {
-                    println!("Error validating user message {:#?}", err)
+                    warn!(
+                        fid = snapchain_txn.fid,
+                        hash = msg.hex_hash(),
+                        "Error validating user message: {:?}",
+                        err
+                    );
                 }
             }
         }
@@ -520,10 +525,6 @@ impl ShardEngine {
             .stores
             .get_usage(fid, msg_type, txn_batch)
             .map_err(|_| EngineError::UsageCountError)?;
-        println!(
-            "Prune messages counts. Current count: {}, Max count: {}",
-            current_count, max_count
-        );
 
         let events = match msg_type {
             MessageType::CastAdd | MessageType::CastRemove => self

--- a/src/storage/store/engine_tests.rs
+++ b/src/storage/store/engine_tests.rs
@@ -864,7 +864,6 @@ mod tests {
         assert_eq!("", to_hex(&state_change.new_state_root));
     }
 
-    #[ignore]
     #[tokio::test]
     async fn test_messages_pruned_with_exceeded_storage() {
         let (mut engine, _tmpdir) = new_engine();
@@ -940,7 +939,6 @@ mod tests {
         );
     }
 
-    #[ignore]
     #[tokio::test]
     async fn test_messages_partially_merged_with_insufficient_storage() {
         let (mut engine, _tmpdir) = new_engine();
@@ -1070,7 +1068,6 @@ mod tests {
         );
     }
 
-    #[ignore]
     #[tokio::test]
     async fn test_revoking_a_signer_deletes_all_messages_from_that_signer() {
         let (mut engine, _tmpdir) = new_engine();

--- a/src/storage/trie/merkle_trie.rs
+++ b/src/storage/trie/merkle_trie.rs
@@ -23,7 +23,9 @@ impl TrieKey {
     pub fn for_message_type(fid: u32, msg_type: u8) -> Vec<u8> {
         let mut key = Vec::new();
         key.extend_from_slice(&Self::for_fid(fid));
-        key.push(msg_type);
+        // Left shift msg_ype by 3 bits so we don't collide with onchain event types.
+        // Supports 8 onchain event types and 32 message types
+        key.push(msg_type << 3);
         key
     }
 
@@ -362,7 +364,6 @@ mod tests {
         }
 
         let key1: Vec<_> = "0000482712".bytes().collect();
-        println!("{:?}", key1);
         trie.insert(ctx, db, &mut txn_batch, vec![key1.clone()])
             .unwrap();
 

--- a/src/storage/trie/merkle_trie_tests.rs
+++ b/src/storage/trie/merkle_trie_tests.rs
@@ -95,14 +95,17 @@ mod tests {
         let message = messages_factory::casts::create_cast_add(1234, "test", None, None);
         let message_key = TrieKey::for_message(&message);
         assert_eq!(message_key[0..4], TrieKey::for_fid(1234));
-        assert_eq!(message_key[4], message.msg_type().into_u8());
+        assert_eq!(message_key[4], message.msg_type().into_u8() << 3);
         assert_eq!(message_key[5..], message.hash);
 
         let delete_message =
             messages_factory::casts::create_cast_remove(321456, &message.hash, None, None);
         let delete_message_key = TrieKey::for_message(&delete_message);
         assert_eq!(delete_message_key[0..4], TrieKey::for_fid(321456));
-        assert_eq!(delete_message_key[4], delete_message.msg_type().into_u8());
+        assert_eq!(
+            delete_message_key[4],
+            delete_message.msg_type().into_u8() << 3
+        );
         assert_eq!(delete_message_key[5..], delete_message.hash);
 
         let event = events_factory::create_onchain_event(1234);


### PR DESCRIPTION
On chain event types were colliding with message types in the trie and throwing off the message counts. Left shit message types by 3 bits so they each get their unique key space.