### PR TITLE
rename SnapchainService to HubService

### DIFF
--- a/src/bin/submit_message.rs
+++ b/src/bin/submit_message.rs
@@ -2,9 +2,7 @@ use clap::Parser;
 use ed25519_dalek::{SecretKey, SigningKey};
 use hex::FromHex;
 use snapchain::utils::cli::compose_message;
-use snapchain::{
-    proto::rpc::snapchain_service_client::SnapchainServiceClient, utils::cli::send_message,
-};
+use snapchain::{proto::rpc::hub_service_client::HubServiceClient, utils::cli::send_message};
 
 #[derive(Parser)]
 struct Cli {
@@ -22,7 +20,7 @@ async fn main() {
             .unwrap(),
     );
 
-    let mut client = SnapchainServiceClient::connect(args.addr).await.unwrap();
+    let mut client = HubServiceClient::connect(args.addr).await.unwrap();
 
     let resp = send_message(
         &mut client,

--- a/src/consensus/proposer.rs
+++ b/src/consensus/proposer.rs
@@ -1,7 +1,7 @@
 use crate::core::types::{
     proto, Address, Height, ShardHash, ShardId, SnapchainShard, SnapchainValidator,
 };
-use crate::proto::rpc::snapchain_service_client::SnapchainServiceClient;
+use crate::proto::rpc::hub_service_client::HubServiceClient;
 use crate::proto::rpc::{BlocksRequest, ShardChunksRequest};
 use crate::proto::snapchain::{Block, BlockHeader, FullProposal, ShardChunk, ShardHeader};
 use crate::storage::store::engine::{BlockEngine, ShardEngine, ShardStateChange};
@@ -177,7 +177,7 @@ impl Proposer for ShardProposer {
             None => return Ok(()),
             Some(rpc_address) => {
                 let destination_addr = format!("http://{}", rpc_address.clone());
-                let mut rpc_client = SnapchainServiceClient::connect(destination_addr).await?;
+                let mut rpc_client = HubServiceClient::connect(destination_addr).await?;
                 let request = Request::new(ShardChunksRequest {
                     shard_id: self.shard_id.shard_id(),
                     start_block_number: prev_block_number + 1,
@@ -391,7 +391,7 @@ impl Proposer for BlockProposer {
             Some(rpc_address) => {
                 info!({ rpc_address }, "Starting block sync against a validator");
                 let destination_addr = format!("http://{}", rpc_address.clone());
-                let mut rpc_client = SnapchainServiceClient::connect(destination_addr).await?;
+                let mut rpc_client = HubServiceClient::connect(destination_addr).await?;
                 let request = Request::new(BlocksRequest {
                     shard_id: self.shard_id.shard_id(),
                     start_block_number: prev_block_number + 1,

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,10 +18,10 @@ use snapchain::core::types::proto;
 use snapchain::network::admin_server::{DbManager, MyAdminService};
 use snapchain::network::gossip::GossipEvent;
 use snapchain::network::gossip::SnapchainGossip;
-use snapchain::network::server::MySnapchainService;
+use snapchain::network::server::MyHubService;
 use snapchain::node::snapchain_node::SnapchainNode;
 use snapchain::proto::admin_rpc::admin_service_server::AdminServiceServer;
-use snapchain::proto::rpc::snapchain_service_server::SnapchainServiceServer;
+use snapchain::proto::rpc::hub_service_server::HubServiceServer;
 use snapchain::storage::db::RocksDB;
 use snapchain::utils::statsd_wrapper::StatsdClientWrapper;
 
@@ -85,11 +85,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     db.open().unwrap();
     let block_store = BlockStore::new(db);
 
-    info!(
-        addr = addr,
-        grpc_addr = grpc_addr,
-        "SnapchainService listening",
-    );
+    info!(addr = addr, grpc_addr = grpc_addr, "HubService listening",);
 
     let keypair = app_config.consensus.keypair().clone();
 
@@ -164,7 +160,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let rpc_block_store = block_store.clone();
     tokio::spawn(async move {
-        let service = MySnapchainService::new(
+        let service = MyHubService::new(
             rpc_block_store,
             rpc_shard_stores,
             rpc_shard_senders,
@@ -172,7 +168,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         );
 
         let resp = Server::builder()
-            .add_service(SnapchainServiceServer::new(service))
+            .add_service(HubServiceServer::new(service))
             .add_service(AdminServiceServer::new(admin_service))
             .serve(grpc_socket_addr)
             .await;

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use crate::core::error::HubError;
 use crate::proto::hub_event::HubEvent;
 use crate::proto::msg as message;
-use crate::proto::rpc::snapchain_service_server::SnapchainService;
+use crate::proto::rpc::hub_service_server::HubService;
 use crate::proto::rpc::{BlocksRequest, ShardChunksRequest, ShardChunksResponse, SubscribeRequest};
 use crate::proto::snapchain::Block;
 use crate::storage::db::PageOptions;
@@ -17,7 +17,7 @@ use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status};
 use tracing::info;
 
-pub struct MySnapchainService {
+pub struct MyHubService {
     block_store: BlockStore,
     shard_stores: HashMap<u32, Stores>,
     shard_senders: HashMap<u32, Senders>,
@@ -25,7 +25,7 @@ pub struct MySnapchainService {
     statsd_client: StatsdClientWrapper,
 }
 
-impl MySnapchainService {
+impl MyHubService {
     pub fn new(
         block_store: BlockStore,
         shard_stores: HashMap<u32, Stores>,
@@ -46,7 +46,7 @@ impl MySnapchainService {
 }
 
 #[tonic::async_trait]
-impl SnapchainService for MySnapchainService {
+impl HubService for MyHubService {
     async fn submit_message(
         &self,
         request: Request<message::Message>,

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -4,9 +4,9 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
-    use crate::network::server::MySnapchainService;
+    use crate::network::server::MyHubService;
     use crate::proto::hub_event::{HubEvent, HubEventType};
-    use crate::proto::rpc::snapchain_service_server::SnapchainService;
+    use crate::proto::rpc::hub_service_server::HubService;
     use crate::proto::rpc::SubscribeRequest;
     use crate::storage::db::{self, RocksDB, RocksDbTransactionBatch};
     use crate::storage::store::engine::Senders;
@@ -19,11 +19,7 @@ mod tests {
     use tokio::sync::{broadcast, mpsc};
     use tonic::Request;
 
-    async fn subscribe_and_listen(
-        service: &MySnapchainService,
-        shard_id: u32,
-        num_events_expected: u64,
-    ) {
+    async fn subscribe_and_listen(service: &MyHubService, shard_id: u32, num_events_expected: u64) {
         let mut listener = service
             .subscribe(Request::new(SubscribeRequest {
                 event_types: vec![HubEventType::MergeMessage as i32],
@@ -86,11 +82,7 @@ mod tests {
         db
     }
 
-    fn make_server() -> (
-        HashMap<u32, Stores>,
-        HashMap<u32, Senders>,
-        MySnapchainService,
-    ) {
+    fn make_server() -> (HashMap<u32, Stores>, HashMap<u32, Senders>, MyHubService) {
         let statsd_client = StatsdClientWrapper::new(
             cadence::StatsdClient::builder("", cadence::NopMetricSink {}).build(),
             true,
@@ -120,7 +112,7 @@ mod tests {
         (
             stores.clone(),
             senders.clone(),
-            MySnapchainService::new(
+            MyHubService::new(
                 BlockStore::new(make_db("blocks.db")),
                 stores,
                 senders,

--- a/src/perf/perftest.rs
+++ b/src/perf/perftest.rs
@@ -1,5 +1,5 @@
 use crate::proto::onchain_event;
-use crate::proto::rpc::snapchain_service_client::SnapchainServiceClient;
+use crate::proto::rpc::hub_service_client::HubServiceClient;
 use crate::proto::snapchain::Block;
 use crate::storage::store::test_helper;
 use crate::utils::cli::{compose_message, follow_blocks, send_message};
@@ -96,7 +96,7 @@ fn start_submit_messages(
             let mut submit_message_timer = time::interval(config.submit_message.interval);
 
             println!("connecting to {}", &rpc_addr);
-            let mut client = match SnapchainServiceClient::connect(rpc_addr.clone()).await {
+            let mut client = match HubServiceClient::connect(rpc_addr.clone()).await {
                 Ok(client) => client,
                 Err(e) => {
                     panic!("Error connecting to {}: {}", &rpc_addr, e);

--- a/src/proto/rpc.proto
+++ b/src/proto/rpc.proto
@@ -29,7 +29,7 @@ message SubscribeRequest {
   optional uint32 shard_index = 5;
 }
 
-service SnapchainService {
+service HubService {
   rpc SubmitMessage(msg.Message) returns (msg.Message);
   rpc GetBlocks(BlocksRequest) returns (stream snapchain.Block);
   rpc GetShardChunks(ShardChunksRequest) returns (ShardChunksResponse);

--- a/src/utils/cli.rs
+++ b/src/utils/cli.rs
@@ -1,7 +1,7 @@
 use crate::proto::admin_rpc::admin_service_client::AdminServiceClient;
 use crate::proto::msg as message;
 use crate::proto::onchain_event::OnChainEvent;
-use crate::proto::rpc::snapchain_service_client::SnapchainServiceClient;
+use crate::proto::rpc::hub_service_client::HubServiceClient;
 use crate::proto::{rpc, snapchain::Block};
 use crate::utils::factory::messages_factory;
 use ed25519_dalek::SigningKey;
@@ -17,7 +17,7 @@ const FETCH_SIZE: u64 = 100;
 // compose_message is a proof-of-concept script, is not guaranteed to be correct,
 // and clearly needs a lot of work. Use at your own risk.
 pub async fn send_message(
-    client: &mut SnapchainServiceClient<Channel>,
+    client: &mut HubServiceClient<Channel>,
     msg: &message::Message,
 ) -> Result<message::Message, Box<dyn Error>> {
     let request = tonic::Request::new(msg.clone());
@@ -52,7 +52,7 @@ pub async fn follow_blocks(
     addr: String,
     block_tx: mpsc::Sender<Block>,
 ) -> Result<(), Box<dyn Error>> {
-    let mut client = rpc::snapchain_service_client::SnapchainServiceClient::connect(addr).await?;
+    let mut client = rpc::hub_service_client::HubServiceClient::connect(addr).await?;
 
     let mut i = 1;
 

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -4,9 +4,9 @@ use std::sync::Arc;
 
 use hex;
 use libp2p::identity::ed25519::Keypair;
-use snapchain::network::server::MySnapchainService;
+use snapchain::network::server::MyHubService;
 use snapchain::node::snapchain_node::SnapchainNode;
-use snapchain::proto::rpc::snapchain_service_server::SnapchainServiceServer;
+use snapchain::proto::rpc::hub_service_server::HubServiceServer;
 use snapchain::proto::snapchain::Block;
 use snapchain::storage::db::{PageOptions, RocksDB};
 use snapchain::storage::store::BlockStore;
@@ -110,7 +110,7 @@ impl NodeForTest {
         let grpc_shard_stores = node.shard_stores.clone();
         let grpc_shard_senders = node.shard_senders.clone();
         tokio::spawn(async move {
-            let service = MySnapchainService::new(
+            let service = MyHubService::new(
                 grpc_block_store,
                 grpc_shard_stores,
                 grpc_shard_senders,
@@ -119,7 +119,7 @@ impl NodeForTest {
 
             let grpc_socket_addr: SocketAddr = addr.parse().unwrap();
             let resp = Server::builder()
-                .add_service(SnapchainServiceServer::new(service))
+                .add_service(HubServiceServer::new(service))
                 .serve(grpc_socket_addr)
                 .await;
 


### PR DESCRIPTION
The service name needs to be the same as it is in the existing hubs for compatibility. 