### PR TITLE
add submitLegacyMessage endpoint

### DIFF
--- a/src/proto/rpc.proto
+++ b/src/proto/rpc.proto
@@ -29,8 +29,16 @@ message SubscribeRequest {
   optional uint32 shard_index = 5;
 }
 
+/** 
+  * This message exists to support uploading messages from existing hubs to new snapchain nodes via HubRpcClient
+  */
+message LegacyMessage {
+  bytes data = 1;
+}
+
 service HubService {
   rpc SubmitMessage(msg.Message) returns (msg.Message);
+  rpc SubmitLegacyMessage(LegacyMessage) returns (LegacyMessage);
   rpc GetBlocks(BlocksRequest) returns (stream snapchain.Block);
   rpc GetShardChunks(ShardChunksRequest) returns (ShardChunksResponse);
   rpc Subscribe(SubscribeRequest) returns (stream hub_event.HubEvent);


### PR DESCRIPTION
We'll use this endpoint for submitting existing hub messages to snapchain nodes. This avoids us needing to remove qualified module names. 