### PR TITLE
create separate service at root namespace for hub compatible rpcs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -19,6 +19,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "src/proto/hub_event.proto",
             "src/proto/username_proof.proto",
             "src/proto/sync_trie.proto",
+            "src/proto/legacy_rpc.proto",
         ],
         &["src/proto"],
     )?;

--- a/src/bin/submit_message.rs
+++ b/src/bin/submit_message.rs
@@ -3,7 +3,7 @@ use ed25519_dalek::{SecretKey, SigningKey};
 use hex::FromHex;
 use snapchain::utils::cli::compose_message;
 use snapchain::{
-    proto::rpc::new_hub_service_client::NewHubServiceClient, utils::cli::send_message,
+    proto::rpc::snapchain_service_client::SnapchainServiceClient, utils::cli::send_message,
 };
 
 #[derive(Parser)]
@@ -22,7 +22,7 @@ async fn main() {
             .unwrap(),
     );
 
-    let mut client = NewHubServiceClient::connect(args.addr).await.unwrap();
+    let mut client = SnapchainServiceClient::connect(args.addr).await.unwrap();
 
     let resp = send_message(
         &mut client,

--- a/src/bin/submit_message.rs
+++ b/src/bin/submit_message.rs
@@ -2,7 +2,9 @@ use clap::Parser;
 use ed25519_dalek::{SecretKey, SigningKey};
 use hex::FromHex;
 use snapchain::utils::cli::compose_message;
-use snapchain::{proto::rpc::hub_service_client::HubServiceClient, utils::cli::send_message};
+use snapchain::{
+    proto::rpc::new_hub_service_client::NewHubServiceClient, utils::cli::send_message,
+};
 
 #[derive(Parser)]
 struct Cli {
@@ -20,7 +22,7 @@ async fn main() {
             .unwrap(),
     );
 
-    let mut client = HubServiceClient::connect(args.addr).await.unwrap();
+    let mut client = NewHubServiceClient::connect(args.addr).await.unwrap();
 
     let resp = send_message(
         &mut client,

--- a/src/consensus/proposer.rs
+++ b/src/consensus/proposer.rs
@@ -1,7 +1,7 @@
 use crate::core::types::{
     proto, Address, Height, ShardHash, ShardId, SnapchainShard, SnapchainValidator,
 };
-use crate::proto::rpc::hub_service_client::HubServiceClient;
+use crate::proto::rpc::new_hub_service_client::NewHubServiceClient;
 use crate::proto::rpc::{BlocksRequest, ShardChunksRequest};
 use crate::proto::snapchain::{Block, BlockHeader, FullProposal, ShardChunk, ShardHeader};
 use crate::storage::store::engine::{BlockEngine, ShardEngine, ShardStateChange};
@@ -177,7 +177,7 @@ impl Proposer for ShardProposer {
             None => return Ok(()),
             Some(rpc_address) => {
                 let destination_addr = format!("http://{}", rpc_address.clone());
-                let mut rpc_client = HubServiceClient::connect(destination_addr).await?;
+                let mut rpc_client = NewHubServiceClient::connect(destination_addr).await?;
                 let request = Request::new(ShardChunksRequest {
                     shard_id: self.shard_id.shard_id(),
                     start_block_number: prev_block_number + 1,
@@ -391,7 +391,7 @@ impl Proposer for BlockProposer {
             Some(rpc_address) => {
                 info!({ rpc_address }, "Starting block sync against a validator");
                 let destination_addr = format!("http://{}", rpc_address.clone());
-                let mut rpc_client = HubServiceClient::connect(destination_addr).await?;
+                let mut rpc_client = NewHubServiceClient::connect(destination_addr).await?;
                 let request = Request::new(BlocksRequest {
                     shard_id: self.shard_id.shard_id(),
                     start_block_number: prev_block_number + 1,

--- a/src/consensus/proposer.rs
+++ b/src/consensus/proposer.rs
@@ -1,7 +1,7 @@
 use crate::core::types::{
     proto, Address, Height, ShardHash, ShardId, SnapchainShard, SnapchainValidator,
 };
-use crate::proto::rpc::new_hub_service_client::NewHubServiceClient;
+use crate::proto::rpc::snapchain_service_client::SnapchainServiceClient;
 use crate::proto::rpc::{BlocksRequest, ShardChunksRequest};
 use crate::proto::snapchain::{Block, BlockHeader, FullProposal, ShardChunk, ShardHeader};
 use crate::storage::store::engine::{BlockEngine, ShardEngine, ShardStateChange};
@@ -177,7 +177,7 @@ impl Proposer for ShardProposer {
             None => return Ok(()),
             Some(rpc_address) => {
                 let destination_addr = format!("http://{}", rpc_address.clone());
-                let mut rpc_client = NewHubServiceClient::connect(destination_addr).await?;
+                let mut rpc_client = SnapchainServiceClient::connect(destination_addr).await?;
                 let request = Request::new(ShardChunksRequest {
                     shard_id: self.shard_id.shard_id(),
                     start_block_number: prev_block_number + 1,
@@ -391,7 +391,7 @@ impl Proposer for BlockProposer {
             Some(rpc_address) => {
                 info!({ rpc_address }, "Starting block sync against a validator");
                 let destination_addr = format!("http://{}", rpc_address.clone());
-                let mut rpc_client = NewHubServiceClient::connect(destination_addr).await?;
+                let mut rpc_client = SnapchainServiceClient::connect(destination_addr).await?;
                 let request = Request::new(BlocksRequest {
                     shard_id: self.shard_id.shard_id(),
                     start_block_number: prev_block_number + 1,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,10 @@ pub mod proto {
         tonic::include_proto!("rpc");
     }
 
+    pub mod legacy_rpc {
+        tonic::include_proto!("_");
+    }
+
     pub mod msg {
         tonic::include_proto!("msg");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use malachite_metrics::{Metrics, SharedRegistry};
 use snapchain::proto::legacy_rpc::hub_service_server::HubServiceServer;
-use snapchain::proto::rpc::new_hub_service_server::NewHubServiceServer;
+use snapchain::proto::rpc::snapchain_service_server::SnapchainServiceServer;
 use snapchain::storage::store::BlockStore;
 use std::error::Error;
 use std::net;
@@ -162,7 +162,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let rpc_block_store = block_store.clone();
     tokio::spawn(async move {
         let resp = Server::builder()
-            .add_service(NewHubServiceServer::new(MyHubService::new(
+            .add_service(SnapchainServiceServer::new(MyHubService::new(
                 rpc_block_store.clone(),
                 rpc_shard_stores.clone(),
                 rpc_shard_senders.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,6 @@
 use malachite_metrics::{Metrics, SharedRegistry};
+use snapchain::proto::legacy_rpc::hub_service_server::HubServiceServer;
+use snapchain::proto::rpc::new_hub_service_server::NewHubServiceServer;
 use snapchain::storage::store::BlockStore;
 use std::error::Error;
 use std::net;
@@ -21,7 +23,6 @@ use snapchain::network::gossip::SnapchainGossip;
 use snapchain::network::server::MyHubService;
 use snapchain::node::snapchain_node::SnapchainNode;
 use snapchain::proto::admin_rpc::admin_service_server::AdminServiceServer;
-use snapchain::proto::rpc::hub_service_server::HubServiceServer;
 use snapchain::storage::db::RocksDB;
 use snapchain::utils::statsd_wrapper::StatsdClientWrapper;
 
@@ -160,15 +161,19 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let rpc_block_store = block_store.clone();
     tokio::spawn(async move {
-        let service = MyHubService::new(
-            rpc_block_store,
-            rpc_shard_stores,
-            rpc_shard_senders,
-            statsd_client.clone(),
-        );
-
         let resp = Server::builder()
-            .add_service(HubServiceServer::new(service))
+            .add_service(NewHubServiceServer::new(MyHubService::new(
+                rpc_block_store.clone(),
+                rpc_shard_stores.clone(),
+                rpc_shard_senders.clone(),
+                statsd_client.clone(),
+            )))
+            .add_service(HubServiceServer::new(MyHubService::new(
+                rpc_block_store.clone(),
+                rpc_shard_stores.clone(),
+                rpc_shard_senders.clone(),
+                statsd_client.clone(),
+            )))
             .add_service(AdminServiceServer::new(admin_service))
             .serve(grpc_socket_addr)
             .await;

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -5,7 +5,7 @@ use crate::proto::hub_event::HubEvent;
 use crate::proto::legacy_rpc::hub_service_server::HubService;
 use crate::proto::legacy_rpc::LegacyMessage;
 use crate::proto::msg as message;
-use crate::proto::rpc::new_hub_service_server::NewHubService;
+use crate::proto::rpc::snapchain_service_server::SnapchainService;
 use crate::proto::rpc::{BlocksRequest, ShardChunksRequest, ShardChunksResponse, SubscribeRequest};
 use crate::proto::snapchain::Block;
 use crate::storage::db::PageOptions;
@@ -99,7 +99,7 @@ impl HubService for MyHubService {
 }
 
 #[tonic::async_trait]
-impl NewHubService for MyHubService {
+impl SnapchainService for MyHubService {
     async fn submit_message(
         &self,
         request: Request<message::Message>,

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -2,11 +2,11 @@ use std::collections::HashMap;
 
 use crate::core::error::HubError;
 use crate::proto::hub_event::HubEvent;
+use crate::proto::legacy_rpc::hub_service_server::HubService;
+use crate::proto::legacy_rpc::LegacyMessage;
 use crate::proto::msg as message;
-use crate::proto::rpc::hub_service_server::HubService;
-use crate::proto::rpc::{
-    BlocksRequest, LegacyMessage, ShardChunksRequest, ShardChunksResponse, SubscribeRequest,
-};
+use crate::proto::rpc::new_hub_service_server::NewHubService;
+use crate::proto::rpc::{BlocksRequest, ShardChunksRequest, ShardChunksResponse, SubscribeRequest};
 use crate::proto::snapchain::Block;
 use crate::storage::db::PageOptions;
 use crate::storage::store::engine::{MempoolMessage, Senders};
@@ -46,6 +46,31 @@ impl MyHubService {
             statsd_client,
         }
     }
+
+    pub async fn submit_mesage(&self, message: message::Message) -> Result<(), Status> {
+        let start_time = std::time::Instant::now();
+
+        let result = self
+            .message_tx
+            .send(MempoolMessage::UserMessage(message))
+            .await;
+
+        match result {
+            Ok(_) => {
+                self.statsd_client.count("rpc.submit_message.success", 1);
+            }
+            Err(_) => {
+                self.statsd_client.count("rpc.submit_message.failure", 1);
+                return Err(Status::internal("failed to submit message"));
+            }
+        }
+
+        let elapsed = start_time.elapsed().as_millis();
+        self.statsd_client
+            .time("rpc.submit_message.duration", elapsed as u64);
+
+        Ok(())
+    }
 }
 
 #[tonic::async_trait]
@@ -54,8 +79,6 @@ impl HubService for MyHubService {
         &self,
         request: Request<LegacyMessage>,
     ) -> Result<Response<LegacyMessage>, Status> {
-        let start_time = std::time::Instant::now();
-
         info!("Received call to [submit_legacy_message] RPC");
 
         let message = message::Message::decode(request.get_ref().data.as_slice())
@@ -67,64 +90,28 @@ impl HubService for MyHubService {
             ))));
         }
 
-        let result = self
-            .message_tx
-            .send(MempoolMessage::UserMessage(message.clone()))
-            .await;
-
-        // Use the same metrics-- we will use legacy messages for performance tests
-        match result {
-            Ok(_) => {
-                self.statsd_client.count("rpc.submit_message.success", 1);
-            }
-            Err(_) => {
-                self.statsd_client.count("rpc.submit_message.failure", 1);
-                return Err(Status::internal("failed to submit message"));
-            }
-        }
-
-        let elapsed = start_time.elapsed().as_millis();
+        self.submit_mesage(message).await?;
 
         let response = Response::new(request.into_inner());
 
-        self.statsd_client
-            .time("rpc.submit_message.duration", elapsed as u64);
-
         Ok(response)
     }
+}
 
+#[tonic::async_trait]
+impl NewHubService for MyHubService {
     async fn submit_message(
         &self,
         request: Request<message::Message>,
     ) -> Result<Response<message::Message>, Status> {
-        let start_time = std::time::Instant::now();
-
         let hash = request.get_ref().hash.encode_hex::<String>();
         info!(hash, "Received call to [submit_message] RPC");
 
         let message = request.into_inner();
 
-        let result = self
-            .message_tx
-            .send(MempoolMessage::UserMessage(message.clone()))
-            .await;
-
-        match result {
-            Ok(_) => {
-                self.statsd_client.count("rpc.submit_message.success", 1);
-            }
-            Err(_) => {
-                self.statsd_client.count("rpc.submit_message.failure", 1);
-                return Err(Status::internal("failed to submit message"));
-            }
-        }
-
-        let elapsed = start_time.elapsed().as_millis();
+        self.submit_mesage(message.clone()).await?;
 
         let response = Response::new(message);
-
-        self.statsd_client
-            .time("rpc.submit_message.duration", elapsed as u64);
 
         Ok(response)
     }

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -6,7 +6,7 @@ mod tests {
 
     use crate::network::server::MyHubService;
     use crate::proto::hub_event::{HubEvent, HubEventType};
-    use crate::proto::rpc::new_hub_service_server::NewHubService;
+    use crate::proto::rpc::snapchain_service_server::SnapchainService;
     use crate::proto::rpc::SubscribeRequest;
     use crate::storage::db::{self, RocksDB, RocksDbTransactionBatch};
     use crate::storage::store::engine::Senders;

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -6,7 +6,7 @@ mod tests {
 
     use crate::network::server::MyHubService;
     use crate::proto::hub_event::{HubEvent, HubEventType};
-    use crate::proto::rpc::hub_service_server::HubService;
+    use crate::proto::rpc::new_hub_service_server::NewHubService;
     use crate::proto::rpc::SubscribeRequest;
     use crate::storage::db::{self, RocksDB, RocksDbTransactionBatch};
     use crate::storage::store::engine::Senders;

--- a/src/perf/perftest.rs
+++ b/src/perf/perftest.rs
@@ -1,5 +1,5 @@
 use crate::proto::onchain_event;
-use crate::proto::rpc::hub_service_client::HubServiceClient;
+use crate::proto::rpc::new_hub_service_client::NewHubServiceClient;
 use crate::proto::snapchain::Block;
 use crate::storage::store::test_helper;
 use crate::utils::cli::{compose_message, follow_blocks, send_message};
@@ -96,7 +96,7 @@ fn start_submit_messages(
             let mut submit_message_timer = time::interval(config.submit_message.interval);
 
             println!("connecting to {}", &rpc_addr);
-            let mut client = match HubServiceClient::connect(rpc_addr.clone()).await {
+            let mut client = match NewHubServiceClient::connect(rpc_addr.clone()).await {
                 Ok(client) => client,
                 Err(e) => {
                     panic!("Error connecting to {}: {}", &rpc_addr, e);

--- a/src/perf/perftest.rs
+++ b/src/perf/perftest.rs
@@ -1,5 +1,5 @@
 use crate::proto::onchain_event;
-use crate::proto::rpc::new_hub_service_client::NewHubServiceClient;
+use crate::proto::rpc::snapchain_service_client::SnapchainServiceClient;
 use crate::proto::snapchain::Block;
 use crate::storage::store::test_helper;
 use crate::utils::cli::{compose_message, follow_blocks, send_message};
@@ -96,7 +96,7 @@ fn start_submit_messages(
             let mut submit_message_timer = time::interval(config.submit_message.interval);
 
             println!("connecting to {}", &rpc_addr);
-            let mut client = match NewHubServiceClient::connect(rpc_addr.clone()).await {
+            let mut client = match SnapchainServiceClient::connect(rpc_addr.clone()).await {
                 Ok(client) => client,
                 Err(e) => {
                     panic!("Error connecting to {}: {}", &rpc_addr, e);

--- a/src/proto/legacy_rpc.proto
+++ b/src/proto/legacy_rpc.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+/** 
+  * This message exists to support uploading messages from existing hubs to new snapchain nodes via HubRpcClient
+  */
+message LegacyMessage {
+  bytes data = 1;
+}
+
+service HubService {
+  rpc SubmitLegacyMessage(LegacyMessage) returns (LegacyMessage);
+};

--- a/src/proto/rpc.proto
+++ b/src/proto/rpc.proto
@@ -36,9 +36,8 @@ message LegacyMessage {
   bytes data = 1;
 }
 
-service HubService {
+service NewHubService {
   rpc SubmitMessage(msg.Message) returns (msg.Message);
-  rpc SubmitLegacyMessage(LegacyMessage) returns (LegacyMessage);
   rpc GetBlocks(BlocksRequest) returns (stream snapchain.Block);
   rpc GetShardChunks(ShardChunksRequest) returns (ShardChunksResponse);
   rpc Subscribe(SubscribeRequest) returns (stream hub_event.HubEvent);

--- a/src/proto/rpc.proto
+++ b/src/proto/rpc.proto
@@ -36,7 +36,7 @@ message LegacyMessage {
   bytes data = 1;
 }
 
-service NewHubService {
+service SnapchainService {
   rpc SubmitMessage(msg.Message) returns (msg.Message);
   rpc GetBlocks(BlocksRequest) returns (stream snapchain.Block);
   rpc GetShardChunks(ShardChunksRequest) returns (ShardChunksResponse);

--- a/src/utils/cli.rs
+++ b/src/utils/cli.rs
@@ -1,7 +1,7 @@
 use crate::proto::admin_rpc::admin_service_client::AdminServiceClient;
 use crate::proto::msg as message;
 use crate::proto::onchain_event::OnChainEvent;
-use crate::proto::rpc::hub_service_client::HubServiceClient;
+use crate::proto::rpc::new_hub_service_client::NewHubServiceClient;
 use crate::proto::{rpc, snapchain::Block};
 use crate::utils::factory::messages_factory;
 use ed25519_dalek::SigningKey;
@@ -17,7 +17,7 @@ const FETCH_SIZE: u64 = 100;
 // compose_message is a proof-of-concept script, is not guaranteed to be correct,
 // and clearly needs a lot of work. Use at your own risk.
 pub async fn send_message(
-    client: &mut HubServiceClient<Channel>,
+    client: &mut NewHubServiceClient<Channel>,
     msg: &message::Message,
 ) -> Result<message::Message, Box<dyn Error>> {
     let request = tonic::Request::new(msg.clone());
@@ -52,7 +52,7 @@ pub async fn follow_blocks(
     addr: String,
     block_tx: mpsc::Sender<Block>,
 ) -> Result<(), Box<dyn Error>> {
-    let mut client = rpc::hub_service_client::HubServiceClient::connect(addr).await?;
+    let mut client = rpc::new_hub_service_client::NewHubServiceClient::connect(addr).await?;
 
     let mut i = 1;
 

--- a/src/utils/cli.rs
+++ b/src/utils/cli.rs
@@ -1,7 +1,7 @@
 use crate::proto::admin_rpc::admin_service_client::AdminServiceClient;
 use crate::proto::msg as message;
 use crate::proto::onchain_event::OnChainEvent;
-use crate::proto::rpc::new_hub_service_client::NewHubServiceClient;
+use crate::proto::rpc::snapchain_service_client::SnapchainServiceClient;
 use crate::proto::{rpc, snapchain::Block};
 use crate::utils::factory::messages_factory;
 use ed25519_dalek::SigningKey;
@@ -17,7 +17,7 @@ const FETCH_SIZE: u64 = 100;
 // compose_message is a proof-of-concept script, is not guaranteed to be correct,
 // and clearly needs a lot of work. Use at your own risk.
 pub async fn send_message(
-    client: &mut NewHubServiceClient<Channel>,
+    client: &mut SnapchainServiceClient<Channel>,
     msg: &message::Message,
 ) -> Result<message::Message, Box<dyn Error>> {
     let request = tonic::Request::new(msg.clone());
@@ -52,7 +52,7 @@ pub async fn follow_blocks(
     addr: String,
     block_tx: mpsc::Sender<Block>,
 ) -> Result<(), Box<dyn Error>> {
-    let mut client = rpc::new_hub_service_client::NewHubServiceClient::connect(addr).await?;
+    let mut client = rpc::snapchain_service_client::SnapchainServiceClient::connect(addr).await?;
 
     let mut i = 1;
 

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -6,7 +6,7 @@ use hex;
 use libp2p::identity::ed25519::Keypair;
 use snapchain::network::server::MyHubService;
 use snapchain::node::snapchain_node::SnapchainNode;
-use snapchain::proto::rpc::new_hub_service_server::NewHubServiceServer;
+use snapchain::proto::rpc::snapchain_service_server::SnapchainServiceServer;
 use snapchain::proto::snapchain::Block;
 use snapchain::storage::db::{PageOptions, RocksDB};
 use snapchain::storage::store::BlockStore;
@@ -119,7 +119,7 @@ impl NodeForTest {
 
             let grpc_socket_addr: SocketAddr = addr.parse().unwrap();
             let resp = Server::builder()
-                .add_service(NewHubServiceServer::new(service))
+                .add_service(SnapchainServiceServer::new(service))
                 .serve(grpc_socket_addr)
                 .await;
 

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -6,7 +6,7 @@ use hex;
 use libp2p::identity::ed25519::Keypair;
 use snapchain::network::server::MyHubService;
 use snapchain::node::snapchain_node::SnapchainNode;
-use snapchain::proto::rpc::hub_service_server::HubServiceServer;
+use snapchain::proto::rpc::new_hub_service_server::NewHubServiceServer;
 use snapchain::proto::snapchain::Block;
 use snapchain::storage::db::{PageOptions, RocksDB};
 use snapchain::storage::store::BlockStore;
@@ -119,7 +119,7 @@ impl NodeForTest {
 
             let grpc_socket_addr: SocketAddr = addr.parse().unwrap();
             let resp = Server::builder()
-                .add_service(HubServiceServer::new(service))
+                .add_service(NewHubServiceServer::new(service))
                 .serve(grpc_socket_addr)
                 .await;
 


### PR DESCRIPTION
Putting `submitLegacyMessage` in the existing rpc service doesn't work due to namespacing issues-- the service is in the "rpc" namespace. Move this endpoint into a new service at the root namespace that exactly matches the proto structure of the parallel hub rpc. 

Future compatible rpcs should go there too. 