### PR TITLE
Revoke username when fname is transferred

### DIFF
--- a/src/storage/store/engine_tests.rs
+++ b/src/storage/store/engine_tests.rs
@@ -1,19 +1,18 @@
 #[cfg(test)]
 mod tests {
-    use crate::proto::HubEvent;
     use crate::proto::ShardChunk;
     use crate::proto::{self, ReactionType};
+    use crate::proto::{HubEvent, ValidatorMessage};
     use crate::proto::{OnChainEvent, OnChainEventType};
     use crate::storage::db::RocksDbTransactionBatch;
     use crate::storage::store::engine::{MempoolMessage, ShardEngine};
     use crate::storage::store::test_helper;
-    use crate::storage::store::test_helper::{register_fname, FID2_FOR_TEST, FID_FOR_TEST};
+    use crate::storage::store::test_helper::{FID2_FOR_TEST, FID_FOR_TEST};
     use crate::storage::trie::merkle_trie;
     use crate::storage::trie::merkle_trie::TrieKey;
     use crate::utils::factory::{self, events_factory, messages_factory, time, username_factory};
     use ed25519_dalek::SigningKey;
     use prost::Message as _;
-    use std::time::Duration;
     use tracing_subscriber::EnvFilter;
 
     fn trie_ctx() -> &'static mut merkle_trie::Context<'static> {
@@ -39,7 +38,7 @@ mod tests {
 
     fn default_message(text: &str) -> proto::Message {
         messages_factory::casts::create_cast_add(
-            test_helper::FID_FOR_TEST,
+            FID_FOR_TEST,
             text,
             Some(0),
             Some(&test_helper::default_signer()),
@@ -47,7 +46,7 @@ mod tests {
     }
 
     fn default_onchain_event() -> OnChainEvent {
-        events_factory::create_onchain_event(test_helper::FID_FOR_TEST)
+        events_factory::create_onchain_event(FID_FOR_TEST)
     }
 
     fn entities() -> (proto::Message, proto::Message) {
@@ -69,7 +68,7 @@ mod tests {
 
     fn assert_merge_event(event: &HubEvent, merged_message: &proto::Message) {
         let generated_event = match &event.body {
-            Some(crate::proto::hub_event::Body::MergeMessageBody(msg)) => msg,
+            Some(proto::hub_event::Body::MergeMessageBody(msg)) => msg,
             _ => panic!("Unexpected event type: {:?}", event.body),
         };
         assert_eq!(
@@ -80,7 +79,7 @@ mod tests {
 
     fn assert_prune_event(event: &HubEvent, pruned_message: &proto::Message) {
         let generated_event = match &event.body {
-            Some(crate::proto::hub_event::Body::PruneMessageBody(msg)) => msg,
+            Some(proto::hub_event::Body::PruneMessageBody(msg)) => msg,
             _ => panic!("Unexpected event type: {:?}", event.body),
         };
         assert_eq!(
@@ -91,7 +90,7 @@ mod tests {
 
     fn assert_revoke_event(event: &HubEvent, revoked_message: &proto::Message) {
         let generated_event = match &event.body {
-            Some(crate::proto::hub_event::Body::RevokeMessageBody(msg)) => msg,
+            Some(proto::hub_event::Body::RevokeMessageBody(msg)) => msg,
             _ => panic!("Unexpected event type: {:?}", event.body),
         };
         assert_eq!(
@@ -102,7 +101,7 @@ mod tests {
 
     fn assert_onchain_hub_event(event: &HubEvent, onchain_event: &OnChainEvent) {
         let generated_event = match &event.body {
-            Some(crate::proto::hub_event::Body::MergeOnChainEventBody(onchain)) => onchain,
+            Some(proto::hub_event::Body::MergeOnChainEventBody(onchain)) => onchain,
             _ => panic!("Unexpected event type: {:?}", event.body),
         }
         .on_chain_event
@@ -116,17 +115,8 @@ mod tests {
     }
 
     async fn commit_message(engine: &mut ShardEngine, msg: &proto::Message) -> ShardChunk {
-        let messages_tx = engine.messages_tx();
-
-        messages_tx
-            .send(MempoolMessage::UserMessage(msg.clone()))
-            .await
-            .unwrap();
-        let messages = engine
-            .pull_messages(Duration::from_millis(50))
-            .await
-            .unwrap();
-        let state_change = engine.propose_state_change(1, messages);
+        let state_change =
+            engine.propose_state_change(1, vec![MempoolMessage::UserMessage(msg.clone())]);
 
         if state_change.transactions.is_empty() {
             panic!("Failed to propose message");
@@ -142,17 +132,8 @@ mod tests {
     }
 
     async fn assert_commit_fails(engine: &mut ShardEngine, msg: &proto::Message) -> ShardChunk {
-        let messages_tx = engine.messages_tx();
-
-        messages_tx
-            .send(MempoolMessage::UserMessage(msg.clone()))
-            .await
-            .unwrap();
-        let messages = engine
-            .pull_messages(Duration::from_millis(50))
-            .await
-            .unwrap();
-        let state_change = engine.propose_state_change(1, messages);
+        let state_change =
+            engine.propose_state_change(1, vec![MempoolMessage::UserMessage(msg.clone())]);
 
         if state_change.transactions.is_empty() {
             panic!("Failed to propose message");
@@ -171,17 +152,11 @@ mod tests {
     #[tokio::test]
     async fn test_engine_basic_propose() {
         let (mut engine, _tmpdir) = test_helper::new_engine();
-        let messages_tx = engine.messages_tx();
-
         // State root starts empty
         assert_eq!("", to_hex(&engine.trie_root_hash()));
 
         // Propose empty transaction
-        let messages = engine
-            .pull_messages(Duration::from_millis(50))
-            .await
-            .unwrap();
-        let state_change = engine.propose_state_change(1, messages);
+        let state_change = engine.propose_state_change(1, vec![]);
         assert_eq!(1, state_change.shard_id);
         assert_eq!(state_change.transactions.len(), 0);
         // No messages so, new state root should be same as before
@@ -190,23 +165,13 @@ mod tests {
         assert_eq!("", to_hex(&engine.trie_root_hash()));
 
         // Propose a message that doesn't require storage
-        messages_tx
-            .send(MempoolMessage::ValidatorMessage(
-                crate::proto::ValidatorMessage {
-                    on_chain_event: Some(events_factory::create_onchain_event(
-                        test_helper::FID_FOR_TEST,
-                    )),
-                    fname_transfer: None,
-                },
-            ))
-            .await
-            .unwrap();
-
-        let messages = engine
-            .pull_messages(Duration::from_millis(50))
-            .await
-            .unwrap();
-        let state_change = engine.propose_state_change(1, messages);
+        let state_change = engine.propose_state_change(
+            1,
+            vec![MempoolMessage::ValidatorMessage(ValidatorMessage {
+                on_chain_event: Some(events_factory::create_onchain_event(FID_FOR_TEST)),
+                fname_transfer: None,
+            })],
+        );
 
         assert_eq!(1, state_change.shard_id);
         assert_eq!(state_change.transactions.len(), 1);
@@ -219,11 +184,7 @@ mod tests {
     #[should_panic(expected = "State change commit failed: merkle trie root hash mismatch")]
     async fn test_engine_commit_with_mismatched_hash() {
         let (mut engine, _tmpdir) = test_helper::new_engine();
-        let messages = engine
-            .pull_messages(Duration::from_millis(50))
-            .await
-            .unwrap();
-        let mut state_change = engine.propose_state_change(1, messages);
+        let mut state_change = engine.propose_state_change(1, vec![]);
         let invalid_hash = from_hex("ffffffffffffffffffffffffffffffffffffffff");
 
         {
@@ -247,11 +208,7 @@ mod tests {
     #[tokio::test]
     async fn test_engine_commit_no_messages_happy_path() {
         let (mut engine, _tmpdir) = test_helper::new_engine();
-        let messages = engine
-            .pull_messages(Duration::from_millis(50))
-            .await
-            .unwrap();
-        let state_change = engine.propose_state_change(1, messages);
+        let state_change = engine.propose_state_change(1, vec![]);
         let expected_roots = vec![""];
 
         test_helper::validate_and_commit_state_change(&mut engine, &state_change);
@@ -267,13 +224,7 @@ mod tests {
         // enable_logging();
         let (msg1, _) = entities();
         let (mut engine, _tmpdir) = test_helper::new_engine();
-        test_helper::register_user(
-            test_helper::FID_FOR_TEST,
-            test_helper::default_signer(),
-            &mut engine,
-        )
-        .await;
-        let messages_tx = engine.messages_tx();
+        test_helper::register_user(FID_FOR_TEST, test_helper::default_signer(), &mut engine).await;
         let mut event_rx = engine.get_senders().events_tx.subscribe();
 
         // Registering a user generates events
@@ -283,15 +234,8 @@ mod tests {
             .len();
         assert_eq!(3, initial_events_count);
 
-        messages_tx
-            .send(MempoolMessage::UserMessage(msg1.clone()))
-            .await
-            .unwrap();
-        let messages = engine
-            .pull_messages(Duration::from_millis(50))
-            .await
-            .unwrap();
-        let state_change = engine.propose_state_change(1, messages);
+        let state_change =
+            engine.propose_state_change(1, vec![MempoolMessage::UserMessage(msg1.clone())]);
 
         assert_eq!(1, state_change.transactions.len());
         assert_eq!(1, state_change.transactions[0].user_messages.len());
@@ -344,19 +288,10 @@ mod tests {
     #[tokio::test]
     async fn test_engine_commit_delete_message() {
         let timestamp = messages_factory::farcaster_time();
-        let cast = messages_factory::casts::create_cast_add(
-            test_helper::FID_FOR_TEST,
-            "msg1",
-            Some(timestamp),
-            None,
-        );
+        let cast =
+            messages_factory::casts::create_cast_add(FID_FOR_TEST, "msg1", Some(timestamp), None);
         let (mut engine, _tmpdir) = test_helper::new_engine();
-        test_helper::register_user(
-            test_helper::FID_FOR_TEST,
-            test_helper::default_signer(),
-            &mut engine,
-        )
-        .await;
+        test_helper::register_user(FID_FOR_TEST, test_helper::default_signer(), &mut engine).await;
 
         commit_message(&mut engine, &cast).await;
 
@@ -373,7 +308,7 @@ mod tests {
 
         // Delete the cast
         let delete_cast = messages_factory::casts::create_cast_remove(
-            test_helper::FID_FOR_TEST,
+            FID_FOR_TEST,
             &cast.hash,
             Some(timestamp + 1),
             None,
@@ -382,7 +317,7 @@ mod tests {
         commit_message(&mut engine, &delete_cast).await;
 
         // The cast is not present in the store
-        let casts_result = engine.get_casts_by_fid(test_helper::FID_FOR_TEST);
+        let casts_result = engine.get_casts_by_fid(FID_FOR_TEST);
         let messages = casts_result.unwrap().messages_bytes;
         assert_eq!(0, messages.len());
 
@@ -402,15 +337,10 @@ mod tests {
         let timestamp = messages_factory::farcaster_time();
         let target_fid = 15;
         let (mut engine, _tmpdir) = test_helper::new_engine();
-        test_helper::register_user(
-            test_helper::FID_FOR_TEST,
-            test_helper::default_signer(),
-            &mut engine,
-        )
-        .await;
+        test_helper::register_user(FID_FOR_TEST, test_helper::default_signer(), &mut engine).await;
 
         let link_add = messages_factory::links::create_link_add(
-            test_helper::FID_FOR_TEST,
+            FID_FOR_TEST,
             "follow".to_string(),
             target_fid,
             Some(timestamp),
@@ -419,11 +349,11 @@ mod tests {
 
         commit_message(&mut engine, &link_add).await;
 
-        let link_result = engine.get_links_by_fid(test_helper::FID_FOR_TEST);
+        let link_result = engine.get_links_by_fid(FID_FOR_TEST);
         assert_eq!(1, link_result.unwrap().messages_bytes.len());
 
         let link_remove = messages_factory::links::create_link_remove(
-            test_helper::FID_FOR_TEST,
+            FID_FOR_TEST,
             "follow".to_string(),
             target_fid,
             Some(timestamp + 1),
@@ -432,11 +362,11 @@ mod tests {
 
         commit_message(&mut engine, &link_remove).await;
 
-        let link_result = engine.get_links_by_fid(test_helper::FID_FOR_TEST);
+        let link_result = engine.get_links_by_fid(FID_FOR_TEST);
         assert_eq!(0, link_result.unwrap().messages_bytes.len());
 
         let link_compact_state = messages_factory::links::create_link_compact_state(
-            test_helper::FID_FOR_TEST,
+            FID_FOR_TEST,
             "follow".to_string(),
             target_fid,
             Some(timestamp + 1),
@@ -445,7 +375,7 @@ mod tests {
 
         commit_message(&mut engine, &link_compact_state).await;
 
-        let link_result = engine.get_link_compact_state_messages_by_fid(test_helper::FID_FOR_TEST);
+        let link_result = engine.get_link_compact_state_messages_by_fid(FID_FOR_TEST);
         assert_eq!(1, link_result.unwrap().messages_bytes.len());
     }
 
@@ -454,15 +384,10 @@ mod tests {
         let timestamp = messages_factory::farcaster_time();
         let target_url = "exampleurl".to_string();
         let (mut engine, _tmpdir) = test_helper::new_engine();
-        test_helper::register_user(
-            test_helper::FID_FOR_TEST,
-            test_helper::default_signer(),
-            &mut engine,
-        )
-        .await;
+        test_helper::register_user(FID_FOR_TEST, test_helper::default_signer(), &mut engine).await;
 
         let reaction_add = messages_factory::reactions::create_reaction_add(
-            test_helper::FID_FOR_TEST,
+            FID_FOR_TEST,
             ReactionType::Like,
             target_url.clone(),
             Some(timestamp),
@@ -471,11 +396,11 @@ mod tests {
 
         commit_message(&mut engine, &reaction_add).await;
 
-        let reaction_result = engine.get_reactions_by_fid(test_helper::FID_FOR_TEST);
+        let reaction_result = engine.get_reactions_by_fid(FID_FOR_TEST);
         assert_eq!(1, reaction_result.unwrap().messages_bytes.len());
 
         let reaction_remove = messages_factory::reactions::create_reaction_remove(
-            test_helper::FID_FOR_TEST,
+            FID_FOR_TEST,
             ReactionType::Like,
             target_url.clone(),
             Some(timestamp),
@@ -484,7 +409,7 @@ mod tests {
 
         commit_message(&mut engine, &reaction_remove).await;
 
-        let reaction_result = engine.get_reactions_by_fid(test_helper::FID_FOR_TEST);
+        let reaction_result = engine.get_reactions_by_fid(FID_FOR_TEST);
         assert_eq!(0, reaction_result.unwrap().messages_bytes.len());
     }
 
@@ -492,15 +417,10 @@ mod tests {
     async fn test_commit_user_data_messages() {
         let timestamp = messages_factory::farcaster_time();
         let (mut engine, _tmpdir) = test_helper::new_engine();
-        test_helper::register_user(
-            test_helper::FID_FOR_TEST,
-            test_helper::default_signer(),
-            &mut engine,
-        )
-        .await;
+        test_helper::register_user(FID_FOR_TEST, test_helper::default_signer(), &mut engine).await;
 
         let user_data_add = messages_factory::user_data::create_user_data_add(
-            test_helper::FID_FOR_TEST,
+            FID_FOR_TEST,
             proto::UserDataType::Bio,
             &"Hi it's me".to_string(),
             Some(timestamp),
@@ -509,7 +429,7 @@ mod tests {
 
         commit_message(&mut engine, &user_data_add).await;
 
-        let user_data_result = engine.get_user_data_by_fid(test_helper::FID_FOR_TEST);
+        let user_data_result = engine.get_user_data_by_fid(FID_FOR_TEST);
         assert_eq!(1, user_data_result.unwrap().messages_bytes.len());
     }
 
@@ -517,16 +437,11 @@ mod tests {
     async fn test_commit_verification_messages() {
         let timestamp = messages_factory::farcaster_time();
         let (mut engine, _tmpdir) = test_helper::new_engine();
-        test_helper::register_user(
-            test_helper::FID_FOR_TEST,
-            test_helper::default_signer(),
-            &mut engine,
-        )
-        .await;
+        test_helper::register_user(FID_FOR_TEST, test_helper::default_signer(), &mut engine).await;
         let address = "address".to_string();
 
         let verification_add = messages_factory::verifications::create_verification_add(
-            test_helper::FID_FOR_TEST,
+            FID_FOR_TEST,
             0,
             address.clone(),
             "signature".to_string(),
@@ -537,11 +452,11 @@ mod tests {
 
         commit_message(&mut engine, &verification_add).await;
 
-        let verification_result = engine.get_verifications_by_fid(test_helper::FID_FOR_TEST);
+        let verification_result = engine.get_verifications_by_fid(FID_FOR_TEST);
         assert_eq!(1, verification_result.unwrap().messages_bytes.len());
 
         let verification_remove = messages_factory::verifications::create_verification_remove(
-            test_helper::FID_FOR_TEST,
+            FID_FOR_TEST,
             address.clone(),
             Some(timestamp),
             None,
@@ -549,7 +464,7 @@ mod tests {
 
         commit_message(&mut engine, &verification_remove).await;
 
-        let verification_result = engine.get_verifications_by_fid(test_helper::FID_FOR_TEST);
+        let verification_result = engine.get_verifications_by_fid(FID_FOR_TEST);
         assert_eq!(0, verification_result.unwrap().messages_bytes.len());
     }
 
@@ -562,11 +477,11 @@ mod tests {
         let signature = "signature".to_string();
         let signer = test_helper::default_signer();
 
-        test_helper::register_user(test_helper::FID_FOR_TEST, signer.clone(), &mut engine).await;
+        test_helper::register_user(FID_FOR_TEST, signer.clone(), &mut engine).await;
 
         let username_proof_add = messages_factory::username_proof::create_username_proof(
-            test_helper::FID_FOR_TEST as u64,
-            crate::proto::UserNameType::UsernameTypeFname,
+            FID_FOR_TEST as u64,
+            proto::UserNameType::UsernameTypeFname,
             name.clone(),
             owner.clone(),
             signature.clone(),
@@ -577,16 +492,14 @@ mod tests {
         commit_message(&mut engine, &username_proof_add).await;
 
         {
-            let username_proof_result =
-                engine.get_username_proofs_by_fid(test_helper::FID2_FOR_TEST);
+            let username_proof_result = engine.get_username_proofs_by_fid(FID2_FOR_TEST);
             assert!(username_proof_result.is_ok());
 
             let messages_bytes_len = username_proof_result.unwrap().messages_bytes.len();
             assert_eq!(0, messages_bytes_len);
         }
         {
-            let username_proof_result =
-                engine.get_username_proofs_by_fid(test_helper::FID_FOR_TEST);
+            let username_proof_result = engine.get_username_proofs_by_fid(FID_FOR_TEST);
             assert!(username_proof_result.is_ok());
 
             let messages_bytes_len = username_proof_result.unwrap().messages_bytes.len();
@@ -599,53 +512,47 @@ mod tests {
 
     #[tokio::test]
     async fn test_account_roots() {
-        let cast =
-            messages_factory::casts::create_cast_add(test_helper::FID_FOR_TEST, "msg1", None, None);
+        let cast = messages_factory::casts::create_cast_add(FID_FOR_TEST, "msg1", None, None);
         let (mut engine, _tmpdir) = test_helper::new_engine();
 
         let txn = &mut RocksDbTransactionBatch::new();
-        let account_root = engine.get_stores().trie.get_hash(
-            &engine.db,
-            txn,
-            &TrieKey::for_fid(test_helper::FID_FOR_TEST),
-        );
+        let account_root =
+            engine
+                .get_stores()
+                .trie
+                .get_hash(&engine.db, txn, &TrieKey::for_fid(FID_FOR_TEST));
         let shard_root = engine.get_stores().trie.root_hash().unwrap();
 
         // Account root and shard root is empty initially
         assert_eq!(account_root.len(), 0);
         assert_eq!(shard_root.len(), 0);
 
-        test_helper::register_user(
-            test_helper::FID_FOR_TEST,
-            test_helper::default_signer(),
-            &mut engine,
-        )
-        .await;
+        test_helper::register_user(FID_FOR_TEST, test_helper::default_signer(), &mut engine).await;
         commit_message(&mut engine, &cast).await;
 
-        let updated_account_root = engine.get_stores().trie.get_hash(
-            &engine.db,
-            txn,
-            &TrieKey::for_fid(test_helper::FID_FOR_TEST),
-        );
+        let updated_account_root =
+            engine
+                .get_stores()
+                .trie
+                .get_hash(&engine.db, txn, &TrieKey::for_fid(FID_FOR_TEST));
         let updated_shard_root = engine.get_stores().trie.root_hash().unwrap();
         // Account root is not empty after a message is committed
         assert_eq!(updated_account_root.len() > 0, true);
         assert_ne!(updated_shard_root, shard_root);
 
-        let another_fid_event = events_factory::create_onchain_event(test_helper::FID_FOR_TEST + 1);
+        let another_fid_event = events_factory::create_onchain_event(FID_FOR_TEST + 1);
         test_helper::commit_event(&mut engine, &another_fid_event).await;
 
-        let account_root_another_fid = engine.get_stores().trie.get_hash(
-            &engine.db,
-            txn,
-            &TrieKey::for_fid(test_helper::FID_FOR_TEST + 1),
-        );
-        let account_root_original_fid = engine.get_stores().trie.get_hash(
-            &engine.db,
-            txn,
-            &TrieKey::for_fid(test_helper::FID_FOR_TEST),
-        );
+        let account_root_another_fid =
+            engine
+                .get_stores()
+                .trie
+                .get_hash(&engine.db, txn, &TrieKey::for_fid(FID_FOR_TEST + 1));
+        let account_root_original_fid =
+            engine
+                .get_stores()
+                .trie
+                .get_hash(&engine.db, txn, &TrieKey::for_fid(FID_FOR_TEST));
         let latest_shard_root = engine.get_stores().trie.root_hash().unwrap();
         // Only the account root for the new fid and the shard root is updated, original fid account root remains the same
         assert_eq!(account_root_another_fid.len() > 0, true);
@@ -658,30 +565,17 @@ mod tests {
         // enable_logging();
         let (msg1, msg2) = entities();
         let (mut engine, _tmpdir) = test_helper::new_engine();
-        let messages_tx = engine.messages_tx();
         let mut previous_root = "".to_string();
 
         let height = engine.get_confirmed_height();
         assert_eq!(height.shard_index, 1);
         assert_eq!(height.block_number, 0);
 
-        test_helper::register_user(
-            test_helper::FID_FOR_TEST,
-            test_helper::default_signer(),
-            &mut engine,
-        )
-        .await;
+        test_helper::register_user(FID_FOR_TEST, test_helper::default_signer(), &mut engine).await;
 
         {
-            messages_tx
-                .send(MempoolMessage::UserMessage(msg1.clone()))
-                .await
-                .unwrap();
-            let messages = engine
-                .pull_messages(Duration::from_millis(50))
-                .await
-                .unwrap();
-            let state_change = engine.propose_state_change(1, messages);
+            let state_change =
+                engine.propose_state_change(1, vec![MempoolMessage::UserMessage(msg1.clone())]);
 
             assert_eq!(1, state_change.shard_id);
             assert_eq!(state_change.transactions.len(), 1);
@@ -703,15 +597,8 @@ mod tests {
         }
 
         {
-            messages_tx
-                .send(MempoolMessage::UserMessage(msg2.clone()))
-                .await
-                .unwrap();
-            let messages = engine
-                .pull_messages(Duration::from_millis(50))
-                .await
-                .unwrap();
-            let state_change = engine.propose_state_change(1, messages);
+            let state_change =
+                engine.propose_state_change(1, vec![MempoolMessage::UserMessage(msg2.clone())]);
 
             assert_eq!(1, state_change.shard_id);
             assert_eq!(state_change.transactions.len(), 1);
@@ -738,28 +625,14 @@ mod tests {
         // enable_logging();
         let (msg1, msg2) = entities();
         let (mut engine, _tmpdir) = test_helper::new_engine();
-        test_helper::register_user(
-            test_helper::FID_FOR_TEST,
-            test_helper::default_signer(),
-            &mut engine,
-        )
-        .await;
-        let messages_tx = engine.messages_tx();
+        test_helper::register_user(FID_FOR_TEST, test_helper::default_signer(), &mut engine).await;
         let mut previous_root = "".to_string();
 
         {
-            messages_tx
-                .send(MempoolMessage::UserMessage(msg1.clone()))
-                .await
-                .unwrap();
-            messages_tx
-                .send(MempoolMessage::UserMessage(msg2.clone()))
-                .await
-                .unwrap();
-            let messages = engine
-                .pull_messages(Duration::from_millis(50))
-                .await
-                .unwrap();
+            let messages = vec![
+                MempoolMessage::UserMessage(msg1.clone()),
+                MempoolMessage::UserMessage(msg2.clone()),
+            ];
             let state_change = engine.propose_state_change(1, messages);
 
             assert_eq!(1, state_change.shard_id);
@@ -791,22 +664,14 @@ mod tests {
     async fn test_engine_send_onchain_event() {
         let onchain_event = default_onchain_event();
         let (mut engine, _tmpdir) = test_helper::new_engine();
-        let messages_tx = engine.messages_tx();
         let mut event_rx = engine.get_senders().events_tx.subscribe();
-        messages_tx
-            .send(MempoolMessage::ValidatorMessage(
-                crate::proto::ValidatorMessage {
-                    on_chain_event: Some(onchain_event.clone()),
-                    fname_transfer: None,
-                },
-            ))
-            .await
-            .unwrap();
-        let messages = engine
-            .pull_messages(Duration::from_millis(50))
-            .await
-            .unwrap();
-        let state_change = engine.propose_state_change(1, messages);
+        let state_change = engine.propose_state_change(
+            1,
+            vec![MempoolMessage::ValidatorMessage(ValidatorMessage {
+                on_chain_event: Some(onchain_event.clone()),
+                fname_transfer: None,
+            })],
+        );
         assert_eq!(1, state_change.shard_id);
         assert_eq!(state_change.transactions.len(), 1);
         assert_eq!(1, state_change.transactions[0].system_messages.len());
@@ -822,10 +687,7 @@ mod tests {
         assert_eq!(height.shard_index, 1);
 
         let stored_onchain_events = engine
-            .get_onchain_events(
-                OnChainEventType::EventTypeIdRegister,
-                test_helper::FID_FOR_TEST,
-            )
+            .get_onchain_events(OnChainEventType::EventTypeIdRegister, FID_FOR_TEST)
             .unwrap();
         assert_eq!(stored_onchain_events.len(), 1);
 
@@ -835,7 +697,7 @@ mod tests {
         assert_eq!(event_rx.recv().await.unwrap(), events.events[0]);
 
         let generated_event = match events.events[0].clone().body {
-            Some(crate::proto::hub_event::Body::MergeOnChainEventBody(e)) => e,
+            Some(proto::hub_event::Body::MergeOnChainEventBody(e)) => e,
             _ => panic!("Unexpected event type"),
         };
         assert_eq!(
@@ -848,25 +710,12 @@ mod tests {
     async fn test_messages_not_merged_with_no_storage() {
         let (mut engine, _tmpdir) = test_helper::new_engine();
 
-        let cast_add = messages_factory::casts::create_cast_add(
-            test_helper::FID_FOR_TEST + 1,
-            "no storage",
-            None,
-            None,
-        );
+        let cast_add =
+            messages_factory::casts::create_cast_add(FID_FOR_TEST + 1, "no storage", None, None);
 
         assert_eq!("", to_hex(&engine.trie_root_hash()));
-        let messages_tx = engine.messages_tx();
-
-        messages_tx
-            .send(MempoolMessage::UserMessage(cast_add.clone()))
-            .await
-            .unwrap();
-        let messages = engine
-            .pull_messages(Duration::from_millis(50))
-            .await
-            .unwrap();
-        let state_change = engine.propose_state_change(1, messages);
+        let state_change =
+            engine.propose_state_change(1, vec![MempoolMessage::UserMessage(cast_add.clone())]);
 
         assert_eq!(0, state_change.transactions.len());
         assert_eq!("", to_hex(&state_change.new_state_root));
@@ -875,40 +724,35 @@ mod tests {
     #[tokio::test]
     async fn test_messages_pruned_with_exceeded_storage() {
         let (mut engine, _tmpdir) = test_helper::new_engine();
-        test_helper::register_user(
-            test_helper::FID_FOR_TEST,
-            test_helper::default_signer(),
-            &mut engine,
-        )
-        .await;
+        test_helper::register_user(FID_FOR_TEST, test_helper::default_signer(), &mut engine).await;
         let mut event_rx = engine.get_senders().events_tx.subscribe();
         let current_time = factory::time::farcaster_time();
         let cast1 = messages_factory::casts::create_cast_add(
-            test_helper::FID_FOR_TEST,
+            FID_FOR_TEST,
             "msg1",
             Some(current_time),
             None,
         );
         let cast2 = messages_factory::casts::create_cast_add(
-            test_helper::FID_FOR_TEST,
+            FID_FOR_TEST,
             "msg2",
             Some(current_time + 1),
             None,
         );
         let cast3 = messages_factory::casts::create_cast_add(
-            test_helper::FID_FOR_TEST,
+            FID_FOR_TEST,
             "msg3",
             Some(current_time + 2),
             None,
         );
         let cast4 = messages_factory::casts::create_cast_add(
-            test_helper::FID_FOR_TEST,
+            FID_FOR_TEST,
             "msg4",
             Some(current_time + 3),
             None,
         );
         let cast5 = messages_factory::casts::create_cast_add(
-            test_helper::FID_FOR_TEST,
+            FID_FOR_TEST,
             "msg5",
             Some(current_time + 4),
             None,
@@ -956,65 +800,52 @@ mod tests {
     async fn test_messages_partially_merged_with_insufficient_storage() {
         let (mut engine, _tmpdir) = test_helper::new_engine();
         let signer = test_helper::default_signer();
-        test_helper::register_user(test_helper::FID_FOR_TEST, signer.clone(), &mut engine).await;
+        test_helper::register_user(FID_FOR_TEST, signer.clone(), &mut engine).await;
         let mut event_rx = engine.get_senders().events_tx.subscribe();
         let current_time = factory::time::farcaster_time();
         let cast1 = messages_factory::casts::create_cast_add(
-            test_helper::FID_FOR_TEST,
+            FID_FOR_TEST,
             "msg1",
             Some(current_time),
             None,
         );
         let cast2 = messages_factory::casts::create_cast_add(
-            test_helper::FID_FOR_TEST,
+            FID_FOR_TEST,
             "msg2",
             Some(current_time + 1),
             Some(&signer),
         );
         let cast3 = messages_factory::casts::create_cast_add(
-            test_helper::FID_FOR_TEST,
+            FID_FOR_TEST,
             "msg3",
             Some(current_time + 2),
             Some(&signer),
         );
         let cast4 = messages_factory::casts::create_cast_add(
-            test_helper::FID_FOR_TEST,
+            FID_FOR_TEST,
             "msg4",
             Some(current_time + 3),
             Some(&signer),
         );
         let cast5 = messages_factory::casts::create_cast_add(
-            test_helper::FID_FOR_TEST,
+            FID_FOR_TEST,
             "msg5",
             Some(current_time + 4),
             Some(&signer),
         );
         let cast6 = messages_factory::casts::create_cast_add(
-            test_helper::FID_FOR_TEST,
+            FID_FOR_TEST,
             "msg6",
             Some(current_time + 5),
             Some(&signer),
         );
 
-        let messages_tx = engine.messages_tx();
-
         // Send first three messages in one block, which should mean there is 1 message left in storage
-        messages_tx
-            .send(MempoolMessage::UserMessage(cast1.clone()))
-            .await
-            .unwrap();
-        messages_tx
-            .send(MempoolMessage::UserMessage(cast2.clone()))
-            .await
-            .unwrap();
-        messages_tx
-            .send(MempoolMessage::UserMessage(cast3.clone()))
-            .await
-            .unwrap();
-        let messages = engine
-            .pull_messages(Duration::from_millis(50))
-            .await
-            .unwrap();
+        let messages = vec![
+            MempoolMessage::UserMessage(cast1.clone()),
+            MempoolMessage::UserMessage(cast2.clone()),
+            MempoolMessage::UserMessage(cast3.clone()),
+        ];
         let state_change = engine.propose_state_change(1, messages);
         test_helper::validate_and_commit_state_change(&mut engine, &state_change);
         assert_merge_event(&event_rx.try_recv().unwrap(), &cast1);
@@ -1022,23 +853,11 @@ mod tests {
         assert_merge_event(&event_rx.try_recv().unwrap(), &cast3);
 
         // Now send the last three messages, all of them should be merged, and the first two should be pruned
-        messages_tx
-            .send(MempoolMessage::UserMessage(cast4.clone()))
-            .await
-            .unwrap();
-        messages_tx
-            .send(MempoolMessage::UserMessage(cast5.clone()))
-            .await
-            .unwrap();
-        messages_tx
-            .send(MempoolMessage::UserMessage(cast6.clone()))
-            .await
-            .unwrap();
-
-        let messages = engine
-            .pull_messages(Duration::from_millis(50))
-            .await
-            .unwrap();
+        let messages = vec![
+            MempoolMessage::UserMessage(cast4.clone()),
+            MempoolMessage::UserMessage(cast5.clone()),
+            MempoolMessage::UserMessage(cast6.clone()),
+        ];
         let state_change = engine.propose_state_change(1, messages);
         let chunk = test_helper::validate_and_commit_state_change(&mut engine, &state_change);
         assert_merge_event(&event_rx.try_recv().unwrap(), &cast4);
@@ -1096,38 +915,33 @@ mod tests {
         let another_signer = &SigningKey::generate(&mut rand::rngs::OsRng);
         let timestamp = factory::time::farcaster_time();
         let msg1 = messages_factory::casts::create_cast_add(
-            test_helper::FID_FOR_TEST,
+            FID_FOR_TEST,
             "msg1",
             Some(timestamp),
             Some(&signer),
         );
         let msg2 = messages_factory::casts::create_cast_add(
-            test_helper::FID_FOR_TEST,
+            FID_FOR_TEST,
             "msg2",
             Some(timestamp + 1),
             Some(&signer),
         );
         let same_fid_different_signer = messages_factory::casts::create_cast_add(
-            test_helper::FID_FOR_TEST,
+            FID_FOR_TEST,
             "msg3",
             None,
             Some(another_signer),
         );
-        let different_fid_same_signer = messages_factory::casts::create_cast_add(
-            test_helper::FID_FOR_TEST + 1,
-            "msg4",
-            None,
-            Some(&signer),
-        );
-        test_helper::register_user(test_helper::FID_FOR_TEST, signer.clone(), &mut engine).await;
+        let different_fid_same_signer =
+            messages_factory::casts::create_cast_add(FID_FOR_TEST + 1, "msg4", None, Some(&signer));
+        test_helper::register_user(FID_FOR_TEST, signer.clone(), &mut engine).await;
         let another_signer_event = events_factory::create_signer_event(
-            test_helper::FID_FOR_TEST,
+            FID_FOR_TEST,
             another_signer.clone(),
             proto::SignerEventType::Add,
         );
         test_helper::commit_event(&mut engine, &another_signer_event).await;
-        test_helper::register_user(test_helper::FID_FOR_TEST + 1, signer.clone(), &mut engine)
-            .await;
+        test_helper::register_user(FID_FOR_TEST + 1, signer.clone(), &mut engine).await;
         let mut event_rx = engine.get_senders().events_tx.subscribe();
 
         commit_message(&mut engine, &msg1).await;
@@ -1140,16 +954,14 @@ mod tests {
         let _ = &event_rx.try_recv().unwrap(); // Ignore merge event
 
         // All 4 messages exist
-        let messages = engine.get_casts_by_fid(test_helper::FID_FOR_TEST).unwrap();
+        let messages = engine.get_casts_by_fid(FID_FOR_TEST).unwrap();
         assert_eq!(3, messages.messages_bytes.len());
-        let messages = engine
-            .get_casts_by_fid(test_helper::FID_FOR_TEST + 1)
-            .unwrap();
+        let messages = engine.get_casts_by_fid(FID_FOR_TEST + 1).unwrap();
         assert_eq!(1, messages.messages_bytes.len());
 
         // Revoke a single signer
         let revoke_event = events_factory::create_signer_event(
-            test_helper::FID_FOR_TEST,
+            FID_FOR_TEST,
             signer.clone(),
             proto::SignerEventType::Remove,
         );
@@ -1161,13 +973,11 @@ mod tests {
         assert_eq!(event_rx.try_recv().is_err(), true); // No more events
 
         // Only the messages from the revoked signer are deleted
-        let messages = engine.get_casts_by_fid(test_helper::FID_FOR_TEST).unwrap();
+        let messages = engine.get_casts_by_fid(FID_FOR_TEST).unwrap();
         assert_eq!(1, messages.messages_bytes.len());
 
         // Different Fid with the same signer is unaffected
-        let messages = engine
-            .get_casts_by_fid(test_helper::FID_FOR_TEST + 1)
-            .unwrap();
+        let messages = engine.get_casts_by_fid(FID_FOR_TEST + 1).unwrap();
         assert_eq!(1, messages.messages_bytes.len());
     }
 
@@ -1175,34 +985,20 @@ mod tests {
     async fn test_merge_fname() {
         let (mut engine, _tmpdir) = test_helper::new_engine();
 
-        test_helper::register_user(
-            test_helper::FID_FOR_TEST,
-            test_helper::default_signer(),
-            &mut engine,
-        )
-        .await;
+        test_helper::register_user(FID_FOR_TEST, test_helper::default_signer(), &mut engine).await;
 
         let fname = &"farcaster".to_string();
 
         let mut event_rx = engine.get_senders().events_tx.subscribe();
-        let messages_tx = engine.messages_tx();
         let fname_transfer = username_factory::create_transfer(FID_FOR_TEST, fname, None, None);
 
-        messages_tx
-            .send(MempoolMessage::ValidatorMessage(
-                crate::proto::ValidatorMessage {
-                    on_chain_event: None,
-                    fname_transfer: Some(fname_transfer.clone()),
-                },
-            ))
-            .await
-            .unwrap();
-
-        let messages = engine
-            .pull_messages(Duration::from_millis(50))
-            .await
-            .unwrap();
-        let state_change = engine.propose_state_change(1, messages);
+        let state_change = engine.propose_state_change(
+            1,
+            vec![MempoolMessage::ValidatorMessage(ValidatorMessage {
+                on_chain_event: None,
+                fname_transfer: Some(fname_transfer.clone()),
+            })],
+        );
         test_helper::validate_and_commit_state_change(&mut engine, &state_change);
 
         // Emits a hub event for the user name proof
@@ -1224,15 +1020,10 @@ mod tests {
     async fn test_username_revoked_when_proof_transferred() {
         let (mut engine, _tmpdir) = test_helper::new_engine();
 
-        test_helper::register_user(
-            test_helper::FID_FOR_TEST,
-            test_helper::default_signer(),
-            &mut engine,
-        )
-        .await;
+        test_helper::register_user(FID_FOR_TEST, test_helper::default_signer(), &mut engine).await;
 
         let fname = &"farcaster".to_string();
-        register_fname(FID_FOR_TEST, fname, None, &mut engine).await;
+        test_helper::register_fname(FID_FOR_TEST, fname, None, &mut engine).await;
 
         let fid_username_msg = messages_factory::user_data::create_user_data_add(
             FID_FOR_TEST,
@@ -1258,12 +1049,10 @@ mod tests {
         );
         let state_change = engine.propose_state_change(
             1,
-            vec![MempoolMessage::ValidatorMessage(
-                proto::ValidatorMessage {
-                    on_chain_event: None,
-                    fname_transfer: Some(transfer),
-                },
-            )],
+            vec![MempoolMessage::ValidatorMessage(ValidatorMessage {
+                on_chain_event: None,
+                fname_transfer: Some(transfer),
+            })],
         );
         test_helper::validate_and_commit_state_change(&mut engine, &state_change);
 
@@ -1282,28 +1071,28 @@ mod tests {
         let (mut engine, _tmpdir) = test_helper::new_engine();
         test_helper::commit_event(
             &mut engine,
-            &test_helper::default_storage_event(test_helper::FID_FOR_TEST),
+            &test_helper::default_storage_event(FID_FOR_TEST),
         )
         .await;
         test_helper::commit_event(
             &mut engine,
-            &factory::events_factory::create_signer_event(
-                test_helper::FID_FOR_TEST,
+            &events_factory::create_signer_event(
+                FID_FOR_TEST,
                 test_helper::default_signer(),
                 proto::SignerEventType::Add,
             ),
         )
         .await;
         assert_commit_fails(&mut engine, &default_message("msg1")).await;
-        let messages = engine.get_casts_by_fid(test_helper::FID_FOR_TEST).unwrap();
+        let messages = engine.get_casts_by_fid(FID_FOR_TEST).unwrap();
         assert_eq!(0, messages.messages_bytes.len());
         let id_register = events_factory::create_id_register_event(
-            test_helper::FID_FOR_TEST,
+            FID_FOR_TEST,
             proto::IdRegisterEventType::Register,
         );
         test_helper::commit_event(&mut engine, &id_register).await;
         commit_message(&mut engine, &default_message("msg1")).await;
-        let messages = engine.get_casts_by_fid(test_helper::FID_FOR_TEST).unwrap();
+        let messages = engine.get_casts_by_fid(FID_FOR_TEST).unwrap();
         assert_eq!(1, messages.messages_bytes.len());
     }
 
@@ -1312,31 +1101,31 @@ mod tests {
         let (mut engine, _tmpdir) = test_helper::new_engine();
         test_helper::commit_event(
             &mut engine,
-            &test_helper::default_storage_event(test_helper::FID_FOR_TEST),
+            &test_helper::default_storage_event(FID_FOR_TEST),
         )
         .await;
         test_helper::commit_event(
             &mut engine,
-            &factory::events_factory::create_id_register_event(
-                test_helper::FID_FOR_TEST,
+            &events_factory::create_id_register_event(
+                FID_FOR_TEST,
                 proto::IdRegisterEventType::Register,
             ),
         )
         .await;
         assert_commit_fails(&mut engine, &default_message("msg1")).await;
-        let messages = engine.get_casts_by_fid(test_helper::FID_FOR_TEST).unwrap();
+        let messages = engine.get_casts_by_fid(FID_FOR_TEST).unwrap();
         assert_eq!(0, messages.messages_bytes.len());
         test_helper::commit_event(
             &mut engine,
-            &factory::events_factory::create_signer_event(
-                test_helper::FID_FOR_TEST,
+            &events_factory::create_signer_event(
+                FID_FOR_TEST,
                 test_helper::default_signer(),
                 proto::SignerEventType::Add,
             ),
         )
         .await;
         commit_message(&mut engine, &default_message("msg1")).await;
-        let messages = engine.get_casts_by_fid(test_helper::FID_FOR_TEST).unwrap();
+        let messages = engine.get_casts_by_fid(FID_FOR_TEST).unwrap();
         assert_eq!(1, messages.messages_bytes.len());
     }
 
@@ -1345,12 +1134,7 @@ mod tests {
         let (mut engine, _tmpdir) = test_helper::new_engine();
         let fname = &"farcaster".to_string();
         test_helper::register_user(FID_FOR_TEST, test_helper::default_signer(), &mut engine).await;
-        test_helper::register_user(
-            test_helper::FID2_FOR_TEST,
-            test_helper::default_signer(),
-            &mut engine,
-        )
-        .await;
+        test_helper::register_user(FID2_FOR_TEST, test_helper::default_signer(), &mut engine).await;
 
         // When fname is not registered, message is not merged
         {
@@ -1369,7 +1153,7 @@ mod tests {
         // When fname is owned by a different fid, message is not merged
         {
             let msg = messages_factory::user_data::create_user_data_add(
-                test_helper::FID2_FOR_TEST,
+                FID2_FOR_TEST,
                 proto::UserDataType::Username,
                 fname,
                 None,

--- a/src/storage/store/test_helper.rs
+++ b/src/storage/store/test_helper.rs
@@ -5,7 +5,6 @@ use crate::storage::trie::merkle_trie;
 use crate::utils::statsd_wrapper::StatsdClientWrapper;
 use ed25519_dalek::{SecretKey, SigningKey};
 use std::sync::Arc;
-use std::time::Duration;
 use tempfile;
 
 use crate::proto;
@@ -96,23 +95,13 @@ pub fn new_engine() -> (ShardEngine, tempfile::TempDir) {
 }
 
 pub async fn commit_event(engine: &mut ShardEngine, event: &OnChainEvent) -> ShardChunk {
-    let messages_tx = engine.messages_tx();
-
-    messages_tx
-        .send(MempoolMessage::ValidatorMessage(
-            crate::proto::ValidatorMessage {
-                on_chain_event: Some(event.clone()),
-                fname_transfer: None,
-            },
-        ))
-        .await
-        .unwrap();
-
-    let messages = engine
-        .pull_messages(Duration::from_millis(50))
-        .await
-        .unwrap();
-    let state_change = engine.propose_state_change(1, messages);
+    let state_change = engine.propose_state_change(
+        1,
+        vec![MempoolMessage::ValidatorMessage(proto::ValidatorMessage {
+            on_chain_event: Some(event.clone()),
+            fname_transfer: None,
+        })],
+    );
 
     validate_and_commit_state_change(engine, &state_change)
 }
@@ -183,22 +172,14 @@ pub async fn register_fname(
     timestamp: Option<u64>,
     engine: &mut ShardEngine,
 ) {
-    let messages_tx = engine.messages_tx();
     let fname_transfer = username_factory::create_transfer(fid, username, timestamp, None);
-    messages_tx
-        .send(MempoolMessage::ValidatorMessage(
-            crate::proto::ValidatorMessage {
-                on_chain_event: None,
-                fname_transfer: Some(fname_transfer),
-            },
-        ))
-        .await
-        .unwrap();
-    let messages = engine
-        .pull_messages(Duration::from_millis(50))
-        .await
-        .unwrap();
-    let state_change = engine.propose_state_change(1, messages);
+    let state_change = engine.propose_state_change(
+        1,
+        vec![MempoolMessage::ValidatorMessage(proto::ValidatorMessage {
+            on_chain_event: None,
+            fname_transfer: Some(fname_transfer),
+        })],
+    );
 
     validate_and_commit_state_change(engine, &state_change);
 }

--- a/src/storage/store/test_helper.rs
+++ b/src/storage/store/test_helper.rs
@@ -177,9 +177,14 @@ pub async fn register_user(fid: u32, signer: SigningKey, engine: &mut ShardEngin
 }
 
 #[allow(dead_code)] // This is used by tests
-pub async fn register_fname(fid: u32, username: &String, engine: &mut ShardEngine) {
+pub async fn register_fname(
+    fid: u32,
+    username: &String,
+    timestamp: Option<u64>,
+    engine: &mut ShardEngine,
+) {
     let messages_tx = engine.messages_tx();
-    let fname_transfer = username_factory::create_transfer(fid, username);
+    let fname_transfer = username_factory::create_transfer(fid, username, timestamp, None);
     messages_tx
         .send(MempoolMessage::ValidatorMessage(
             crate::proto::ValidatorMessage {

--- a/src/utils/factory.rs
+++ b/src/utils/factory.rs
@@ -496,9 +496,10 @@ pub mod username_factory {
         fid: u64,
         username_type: crate::proto::UserNameType,
         name: &String,
+        timestamp: Option<u64>,
     ) -> UserNameProof {
         UserNameProof {
-            timestamp: time::current_timestamp() as u64,
+            timestamp: timestamp.unwrap_or_else(|| time::current_timestamp() as u64),
             name: name.as_bytes().to_vec(),
             owner: rand::random::<[u8; 32]>().to_vec(),
             signature: rand::random::<[u8; 32]>().to_vec(),
@@ -507,14 +508,20 @@ pub mod username_factory {
         }
     }
 
-    pub fn create_transfer(fid: u32, name: &String) -> FnameTransfer {
+    pub fn create_transfer(
+        fid: u32,
+        name: &String,
+        timestamp: Option<u64>,
+        from_fid: Option<u32>,
+    ) -> FnameTransfer {
         FnameTransfer {
             id: rand::random::<u64>(),
-            from_fid: 0,
+            from_fid: from_fid.unwrap_or_else(|| 0) as u64,
             proof: Some(create_username_proof(
                 fid as u64,
                 crate::proto::UserNameType::UsernameTypeFname,
                 name,
+                timestamp,
             )),
         }
     }


### PR DESCRIPTION
We need to revoke an existing username when the fname is transferred to a different fid