### PR TITLE
add endpoint for message counts by fid

### DIFF
--- a/src/proto/rpc.proto
+++ b/src/proto/rpc.proto
@@ -51,6 +51,14 @@ message GetInfoResponse {
   DbStats db_stats = 5;
 }
 
+message GetInfoByFidRequest {
+  uint32 fid = 1;
+}
+
+message GetInfoByFidResponse {
+    map<uint32, uint64> num_messages_by_message_type = 3;
+}
+
 service HubService {
   rpc SubmitMessage(Message) returns (Message);
   rpc SubmitMessageWithOptions(SubmitMessageRequest) returns (SubmitMessageResponse);
@@ -58,4 +66,5 @@ service HubService {
   rpc GetShardChunks(ShardChunksRequest) returns (ShardChunksResponse);
   rpc Subscribe(SubscribeRequest) returns (stream HubEvent);
   rpc GetInfo(GetInfoRequest) returns (GetInfoResponse);
+  rpc GetInfoByFid(GetInfoByFidRequest) returns (GetInfoByFidResponse);
 };


### PR DESCRIPTION
It's useful to have visibility into which message types have differing counts for reach fid to validate the migration.

```
❯ grpcurl -plaintext -proto src/proto/rpc.proto -import-path src/proto -d '{"fid": 503}' 127.0.0.1:3383 HubService/GetInfoByFid
{
  "numMessagesByMessageType": {
    "1": "100",
    "2": "0",
    "3": "386",
    "4": "17",
    "5": "97",
    "6": "0",
    "7": "0",
    "8": "0",
    "11": "0",
    "12": "0",
    "13": "0",
    "14": "0"
  }
}
```