### PR TITLE
add overall fid message count to stats

### DIFF
--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -326,8 +326,14 @@ impl HubService for MyHubService {
             MessageType::LinkCompactState,
         ];
         let mut num_messages_by_message_type = HashMap::new();
+        let mut num_messages = 0;
         let fid = request.get_ref().fid;
         for (_, shard_store) in self.shard_stores.iter() {
+            num_messages += shard_store.trie.get_count(
+                &shard_store.db,
+                &mut RocksDbTransactionBatch::new(),
+                &TrieKey::for_fid(fid),
+            );
             for message_type in message_types {
                 num_messages_by_message_type.insert(
                     message_type as u32,
@@ -341,6 +347,7 @@ impl HubService for MyHubService {
         }
 
         Ok(Response::new(GetInfoByFidResponse {
+            num_messages,
             num_messages_by_message_type,
         }))
     }

--- a/src/proto/rpc.proto
+++ b/src/proto/rpc.proto
@@ -56,7 +56,8 @@ message GetInfoByFidRequest {
 }
 
 message GetInfoByFidResponse {
-    map<uint32, uint64> num_messages_by_message_type = 3;
+    uint64 num_messages = 1;
+    map<uint32, uint64> num_messages_by_message_type = 2;
 }
 
 service HubService {


### PR DESCRIPTION
Add overall per-fid message count to the `GetInfoByFid` rpc response. This is useful for understanding message count discrepancies in onchain events. 

```
❯ grpcurl -plaintext -proto src/proto/rpc.proto -import-path src/proto -d '{"fid": 522}' 127.0.0.1:3383 HubService/GetInfoByFid
{
  "numMessages": "70",
  "numMessagesByMessageType": {
    "1": "14",
    "2": "0",
    "3": "0",
    "4": "0",
    "5": "49",
    "6": "0",
    "7": "0",
    "8": "0",
    "11": "3",
    "12": "0",
    "13": "0",
    "14": "0"
  }
}
```