### PR TITLE
add log index to onchain event trie key

### DIFF
--- a/src/storage/trie/merkle_trie.rs
+++ b/src/storage/trie/merkle_trie.rs
@@ -33,6 +33,7 @@ impl TrieKey {
         key.extend_from_slice(&Self::for_fid(event.fid as u32));
         key.push(event.r#type as u8);
         key.extend_from_slice(&event.transaction_hash);
+        key.extend_from_slice(&event.log_index.to_be_bytes());
         key
     }
 

--- a/src/storage/trie/merkle_trie_tests.rs
+++ b/src/storage/trie/merkle_trie_tests.rs
@@ -112,6 +112,13 @@ mod tests {
         let event_key = TrieKey::for_onchain_event(&event);
         assert_eq!(event_key[0..4], TrieKey::for_fid(1234));
         assert_eq!(event_key[4], event.r#type as u8);
-        assert_eq!(event_key[5..], event.transaction_hash);
+        assert_eq!(
+            event_key[5..(5 + event.transaction_hash.len())],
+            event.transaction_hash
+        );
+        assert_eq!(
+            event_key[(5 + event.transaction_hash.len())..],
+            event.log_index.to_be_bytes()
+        );
     }
 }


### PR DESCRIPTION
Sometimes there are multiple signers created in the same transaction. We need log index to differentiate them. 