### PR TITLE
decode message bytes in submit_message

### DIFF
--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -14,6 +14,7 @@ use crate::storage::constants::OnChainEventPostfix;
 use crate::storage::constants::RootPrefix;
 use crate::storage::db::PageOptions;
 use crate::storage::db::RocksDbTransactionBatch;
+use crate::storage::store::account::message_bytes_decode;
 use crate::storage::store::account::CastStore;
 use crate::storage::store::engine::{MempoolMessage, Senders, ShardEngine};
 use crate::storage::store::stores::{StoreLimits, Stores};
@@ -183,7 +184,8 @@ impl HubService for MyHubService {
         let hash = request.get_ref().hash.encode_hex::<String>();
         info!(hash, "Received call to [submit_message] RPC");
 
-        let message = request.into_inner();
+        let mut message = request.into_inner();
+        message_bytes_decode(&mut message);
         let response_message = self.submit_message_internal(message, false).await?;
 
         self.statsd_client.time(

--- a/src/storage/store/account/message.rs
+++ b/src/storage/store/account/message.rs
@@ -254,17 +254,18 @@ pub fn message_encode(message: &MessageProto) -> Vec<u8> {
     }
 }
 
+pub fn message_bytes_decode(msg: &mut MessageProto) {
+    if msg.data.is_none() && msg.data_bytes.is_some() && msg.data_bytes.as_ref().unwrap().len() > 0
+    {
+        if let Ok(msg_data) = MessageData::decode(msg.data_bytes.as_ref().unwrap().as_slice()) {
+            msg.data = Some(msg_data);
+        }
+    }
+}
+
 pub fn message_decode(bytes: &[u8]) -> Result<MessageProto, RocksdbError> {
     if let Ok(mut msg) = MessageProto::decode(bytes) {
-        if msg.data.is_none()
-            && msg.data_bytes.is_some()
-            && msg.data_bytes.as_ref().unwrap().len() > 0
-        {
-            if let Ok(msg_data) = MessageData::decode(msg.data_bytes.as_ref().unwrap().as_slice()) {
-                msg.data = Some(msg_data);
-            }
-        }
-
+        message_bytes_decode(&mut msg);
         Ok(msg)
     } else {
         Err(RocksdbError::DecodeError)


### PR DESCRIPTION
Decode message bytes in `submit_message` rather than submitting messages with both `data` and `data_bytes` populated. This ensures that `data` is consistent with `data_bytes`. 