### PR TITLE
Refactor fid type to use u64 everywhere

### DIFF
--- a/src/core/message.rs
+++ b/src/core/message.rs
@@ -6,9 +6,9 @@ impl proto::Message {
         self.data.is_some() && self.data.as_ref().unwrap().r#type == message_type as i32
     }
 
-    pub fn fid(&self) -> u32 {
+    pub fn fid(&self) -> u64 {
         if self.data.is_some() {
-            self.data.as_ref().unwrap().fid as u32
+            self.data.as_ref().unwrap().fid
         } else {
             0
         }
@@ -28,14 +28,14 @@ impl proto::Message {
 }
 
 impl proto::ValidatorMessage {
-    pub fn fid(&self) -> u32 {
+    pub fn fid(&self) -> u64 {
         if let Some(fname) = &self.fname_transfer {
             if let Some(proof) = &fname.proof {
-                return proof.fid as u32;
+                return proof.fid;
             }
         }
         if let Some(event) = &self.on_chain_event {
-            return event.fid as u32;
+            return event.fid;
         }
         0
     }

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -22,7 +22,7 @@ pub const FARCASTER_EPOCH: u64 = 1609459200; // January 1, 2021 UTC
 
 // Fid must be a 32 bit unsigned integer for storage in RocksDB and the trie.
 // However, protobuf uses 64 bit unsigned integers. So, map to the fid at the lowest level
-pub type Fid = u32;
+pub type FidOnDisk = u32;
 
 pub trait ShardId
 where

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -20,6 +20,10 @@ pub use proto::ShardHash;
 
 pub const FARCASTER_EPOCH: u64 = 1609459200; // January 1, 2021 UTC
 
+// Fid must be a 32 bit unsigned integer for storage in RocksDB and the trie.
+// However, protobuf uses 64 bit unsigned integers. So, map to the fid at the lowest level
+pub type Fid = u32;
+
 pub trait ShardId
 where
     Self: Sized + Clone + Send + Sync + 'static,

--- a/src/mempool/routing.rs
+++ b/src/mempool/routing.rs
@@ -1,4 +1,4 @@
-use crate::core::types::Fid;
+use crate::core::types::FidOnDisk;
 use sha2::{Digest, Sha256};
 
 pub trait MessageRouter: Send + Sync {
@@ -9,7 +9,7 @@ pub struct ShardRouter {}
 
 impl MessageRouter for ShardRouter {
     fn route_message(&self, fid: u64, num_shards: u32) -> u32 {
-        let hash = Sha256::digest((fid as Fid).to_be_bytes());
+        let hash = Sha256::digest((fid as FidOnDisk).to_be_bytes());
         let hash_u32 = u32::from_be_bytes(hash[..4].try_into().unwrap());
         (hash_u32 % num_shards) + 1
     }

--- a/src/mempool/routing.rs
+++ b/src/mempool/routing.rs
@@ -1,14 +1,15 @@
+use crate::core::types::Fid;
 use sha2::{Digest, Sha256};
 
 pub trait MessageRouter: Send + Sync {
-    fn route_message(&self, fid: u32, num_shards: u32) -> u32;
+    fn route_message(&self, fid: u64, num_shards: u32) -> u32;
 }
 
 pub struct ShardRouter {}
 
 impl MessageRouter for ShardRouter {
-    fn route_message(&self, fid: u32, num_shards: u32) -> u32 {
-        let hash = Sha256::digest(fid.to_be_bytes());
+    fn route_message(&self, fid: u64, num_shards: u32) -> u32 {
+        let hash = Sha256::digest((fid as Fid).to_be_bytes());
         let hash_u32 = u32::from_be_bytes(hash[..4].try_into().unwrap());
         (hash_u32 % num_shards) + 1
     }
@@ -17,7 +18,7 @@ impl MessageRouter for ShardRouter {
 // Meant only for tests
 pub struct EvenOddRouterForTest {}
 impl MessageRouter for EvenOddRouterForTest {
-    fn route_message(&self, fid: u32, num_shards: u32) -> u32 {
+    fn route_message(&self, fid: u64, num_shards: u32) -> u32 {
         if num_shards > 2 {
             panic!("EvenOddRouterForTest only supports 2 shards");
         }

--- a/src/network/admin_server.rs
+++ b/src/network/admin_server.rs
@@ -129,7 +129,7 @@ impl AdminService for MyAdminService {
 
         let onchain_event = request.into_inner();
 
-        let fid = onchain_event.fid as u32;
+        let fid = onchain_event.fid;
         if fid == 0 {
             return Err(Status::invalid_argument(
                 "no fid or invalid fid".to_string(),

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -330,7 +330,7 @@ impl HubService for MyHubService {
         ];
         let mut num_messages_by_message_type = HashMap::new();
         let mut num_messages = 0;
-        let fid = request.get_ref().fid;
+        let fid = request.get_ref().fid as u64;
         for (_, shard_store) in self.shard_stores.iter() {
             num_messages += shard_store.trie.get_count(
                 &shard_store.db,
@@ -455,7 +455,7 @@ impl HubService for MyHubService {
         let cast_id = request.into_inner();
         let shard_id = self
             .message_router
-            .route_message(cast_id.fid as u32, self.num_shards);
+            .route_message(cast_id.fid, self.num_shards);
         let stores = match self.shard_stores.get(&shard_id) {
             Some(store) => store,
             None => {
@@ -464,7 +464,7 @@ impl HubService for MyHubService {
                 ))
             }
         };
-        let result = CastStore::get_cast_add(&stores.cast_store, cast_id.fid as u32, cast_id.hash);
+        let result = CastStore::get_cast_add(&stores.cast_store, cast_id.fid, cast_id.hash);
         match result {
             Ok(Some(message)) => Ok(Response::new(message)),
             Ok(None) => Err(Status::not_found("cast not found")),

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -132,8 +132,8 @@ mod tests {
         let blocks_store = BlockStore::new(make_db(&blocks_dir, "blocks.db"));
 
         let message_router = Box::new(routing::EvenOddRouterForTest {});
-        assert_eq!(message_router.route_message(SHARD1_FID as u32, 2), 1);
-        assert_eq!(message_router.route_message(SHARD2_FID as u32, 2), 2);
+        assert_eq!(message_router.route_message(SHARD1_FID, 2), 1);
+        assert_eq!(message_router.route_message(SHARD2_FID, 2), 2);
 
         (
             stores.clone(),
@@ -219,21 +219,19 @@ mod tests {
         let (_, _, [mut engine1, mut engine2], service) = make_server();
         let engine1 = &mut engine1;
         let engine2 = &mut engine2;
-        test_helper::register_user(SHARD1_FID as u32, test_helper::default_signer(), engine1).await;
-        test_helper::register_user(SHARD2_FID as u32, test_helper::default_signer(), engine2).await;
-        let cast_add =
-            messages_factory::casts::create_cast_add(SHARD1_FID as u32, "test", None, None);
-        let cast_add2 =
-            messages_factory::casts::create_cast_add(SHARD1_FID as u32, "test2", None, None);
+        test_helper::register_user(SHARD1_FID, test_helper::default_signer(), engine1).await;
+        test_helper::register_user(SHARD2_FID, test_helper::default_signer(), engine2).await;
+        let cast_add = messages_factory::casts::create_cast_add(SHARD1_FID, "test", None, None);
+        let cast_add2 = messages_factory::casts::create_cast_add(SHARD1_FID, "test2", None, None);
         let cast_remove = messages_factory::casts::create_cast_remove(
-            SHARD1_FID as u32,
+            SHARD1_FID,
             &cast_add.hash,
             Some(cast_add.data.as_ref().unwrap().timestamp + 1),
             None,
         );
 
         let another_shard_cast =
-            messages_factory::casts::create_cast_add(SHARD2_FID as u32, "another fid", None, None);
+            messages_factory::casts::create_cast_add(SHARD2_FID, "another fid", None, None);
 
         test_helper::commit_message(engine1, &cast_add).await;
         test_helper::commit_message(engine1, &cast_add2).await;

--- a/src/perf/gen_multi.rs
+++ b/src/perf/gen_multi.rs
@@ -8,7 +8,7 @@ use rand::Rng;
 use std::collections::HashSet;
 
 pub struct MultiUser {
-    initialized_fids: HashSet<u32>,
+    initialized_fids: HashSet<u64>,
     private_key: SigningKey,
     thread_id: u32,
 }
@@ -27,7 +27,7 @@ impl MessageGenerator for MultiUser {
     fn next(&mut self, seq: u64) -> Vec<NextMessage> {
         let mut rng = rand::thread_rng();
 
-        let fid: u32 = rng.gen_range(1..=5000) + 1_000_000 * self.thread_id;
+        let fid: u64 = rng.gen_range(1..=5000) + 1_000_000 * self.thread_id as u64;
         let mut messages = Vec::new();
 
         // If the FID has not been initialized, return initial messages

--- a/src/perf/gen_single.rs
+++ b/src/perf/gen_single.rs
@@ -25,7 +25,7 @@ impl MessageGenerator for SingleUser {
     fn next(&mut self, seq: u64) -> Vec<NextMessage> {
         let mut messages = Vec::new();
 
-        let fid = self.thread_id * 1_000_000;
+        let fid = (self.thread_id * 1_000_000) as u64;
 
         if !self.initialized {
             self.initialized = true;

--- a/src/storage/store/account/cast_store.rs
+++ b/src/storage/store/account/cast_store.rs
@@ -1,6 +1,6 @@
 use super::{
     get_many_messages_as_bytes, make_cast_id_key, make_fid_key, make_message_primary_key,
-    make_user_key,
+    make_user_key, read_fid_key, read_ts_hash,
     store::{Store, StoreDef},
     MessagesPage, StoreEventHandler, HASH_LENGTH, PAGE_SIZE_MAX, TRUE_VALUE, TS_HASH_LENGTH,
 };
@@ -12,7 +12,7 @@ use crate::{
     proto::{self as message, Message, MessageType},
     storage::db::{RocksDB, RocksDbTransactionBatch},
 };
-use std::{borrow::Borrow, convert::TryInto, sync::Arc};
+use std::{borrow::Borrow, sync::Arc};
 
 type Parent = message::cast_add_body::Parent;
 
@@ -449,12 +449,10 @@ impl CastStore {
                 let ts_hash_offset = prefix.len();
                 let fid_offset = ts_hash_offset + TS_HASH_LENGTH;
 
-                let fid = u32::from_be_bytes(key[fid_offset..fid_offset + 4].try_into().unwrap());
-                let ts_hash = key[ts_hash_offset..ts_hash_offset + TS_HASH_LENGTH]
-                    .try_into()
-                    .unwrap();
+                let fid = read_fid_key(key, fid_offset);
+                let ts_hash = read_ts_hash(key, ts_hash_offset);
                 let message_primary_key =
-                    make_message_primary_key(fid as u64, store.postfix(), Some(&ts_hash));
+                    make_message_primary_key(fid, store.postfix(), Some(&ts_hash));
 
                 message_keys.push(message_primary_key.to_vec());
                 if message_keys.len() >= page_options.page_size.unwrap_or(PAGE_SIZE_MAX) {
@@ -497,12 +495,10 @@ impl CastStore {
                 let ts_hash_offset = prefix.len();
                 let fid_offset = ts_hash_offset + TS_HASH_LENGTH;
 
-                let fid = u32::from_be_bytes(key[fid_offset..fid_offset + 4].try_into().unwrap());
-                let ts_hash = key[ts_hash_offset..ts_hash_offset + TS_HASH_LENGTH]
-                    .try_into()
-                    .unwrap();
+                let fid = read_fid_key(key, fid_offset);
+                let ts_hash = read_ts_hash(key, ts_hash_offset);
                 let message_primary_key =
-                    make_message_primary_key(fid as u64, store.postfix(), Some(&ts_hash));
+                    make_message_primary_key(fid, store.postfix(), Some(&ts_hash));
 
                 message_keys.push(message_primary_key.to_vec());
                 if message_keys.len() >= page_options.page_size.unwrap_or(PAGE_SIZE_MAX) {

--- a/src/storage/store/account/link_store.rs
+++ b/src/storage/store/account/link_store.rs
@@ -77,13 +77,13 @@ impl LinkStore {
     /// * `target` - id of the fid being linked to
     pub fn get_link_add(
         store: &Store<LinkStore>,
-        fid: u32,
+        fid: u64,
         r#type: String,
         target: Option<Target>,
     ) -> Result<Option<Message>, HubError> {
         let partial_message = Message {
             data: Some(MessageData {
-                fid: fid as u64,
+                fid,
                 r#type: MessageType::LinkAdd.into(),
                 body: Some(Body::LinkBody(LinkBody {
                     r#type,
@@ -105,7 +105,7 @@ impl LinkStore {
             }
             return get_message(
                 store.db().borrow(),
-                partial_message.data.as_ref().unwrap().fid as u32,
+                partial_message.data.as_ref().unwrap().fid,
                 store.store_def().postfix(),
                 &vec_to_u8_24(&message_ts_hash)?,
             );
@@ -115,7 +115,7 @@ impl LinkStore {
 
     pub fn get_link_adds_by_fid(
         store: &Store<LinkStore>,
-        fid: u32,
+        fid: u64,
         r#type: String,
         page_options: &PageOptions,
     ) -> Result<MessagesPage, HubError> {
@@ -136,7 +136,7 @@ impl LinkStore {
 
     pub fn get_link_compact_state_message_by_fid(
         store: &Store<LinkStore>,
-        fid: u32,
+        fid: u64,
         page_options: &PageOptions,
     ) -> Result<MessagesPage, HubError> {
         store.get_compact_state_messages_by_fid(fid, page_options)
@@ -168,7 +168,7 @@ impl LinkStore {
                         .try_into()
                         .unwrap();
                     let message_primary_key =
-                        make_message_primary_key(fid, store.postfix(), Some(&ts_hash));
+                        make_message_primary_key(fid as u64, store.postfix(), Some(&ts_hash));
 
                     message_keys.push(message_primary_key.to_vec());
                     if message_keys.len() >= page_options.page_size.unwrap_or(PAGE_SIZE_MAX) {
@@ -204,13 +204,13 @@ impl LinkStore {
     /// * `target` - id of the fid being linked to
     pub fn get_link_remove(
         store: &Store<LinkStore>,
-        fid: u32,
+        fid: u64,
         r#type: String,
         target: Option<Target>,
     ) -> Result<Option<Message>, HubError> {
         let partial_message = Message {
             data: Some(MessageData {
-                fid: fid as u64,
+                fid,
                 r#type: MessageType::LinkRemove.into(),
                 body: Some(Body::LinkBody(LinkBody {
                     r#type,
@@ -232,7 +232,7 @@ impl LinkStore {
             }
             return get_message(
                 store.db().borrow(),
-                partial_message.data.as_ref().unwrap().fid as u32,
+                partial_message.data.as_ref().unwrap().fid,
                 store.store_def().postfix(),
                 &vec_to_u8_24(&message_ts_hash)?,
             );
@@ -241,7 +241,7 @@ impl LinkStore {
     }
 
     // Generates a unique key used to store a LinkCompactState message key in the store
-    fn link_compact_state_add_key(fid: u32, link_type: &String) -> Result<Vec<u8>, HubError> {
+    fn link_compact_state_add_key(fid: u64, link_type: &String) -> Result<Vec<u8>, HubError> {
         let mut key = Vec::with_capacity(
             Self::ROOT_PREFIXED_FID_BYTE_SIZE + Self::POSTFIX_BYTE_SIZE + Self::LINK_TYPE_BYTE_SIZE,
         );
@@ -263,7 +263,7 @@ impl LinkStore {
     /// * `fid` - farcaster id of the user who created the link
     /// * `link_body` - body of link that contains type of link created and target ID of the object
     ///                 being reacted to
-    fn link_add_key(fid: u32, link_body: &LinkBody, padded: bool) -> Result<Vec<u8>, HubError> {
+    fn link_add_key(fid: u64, link_body: &LinkBody, padded: bool) -> Result<Vec<u8>, HubError> {
         if link_body.target.is_some()
             && (link_body.r#type.is_empty() || link_body.r#type.len() == 0)
         {
@@ -298,7 +298,7 @@ impl LinkStore {
         match link_body.target {
             None => {}
             Some(Target::TargetFid(fid)) => {
-                key.extend_from_slice(&make_fid_key(fid as u32)[..Self::TARGET_ID_BYTE_SIZE])
+                key.extend_from_slice(&make_fid_key(fid)[..Self::TARGET_ID_BYTE_SIZE])
             }
         }
 
@@ -312,7 +312,7 @@ impl LinkStore {
     /// * `fid` - farcaster id of the user who created the link
     /// * `link_body` - body of link that contains type of link created and target ID of the object
     ///                 being reacted to
-    fn link_remove_key(fid: u32, link_body: &LinkBody, padded: bool) -> Result<Vec<u8>, HubError> {
+    fn link_remove_key(fid: u64, link_body: &LinkBody, padded: bool) -> Result<Vec<u8>, HubError> {
         if link_body.target.is_some()
             && (link_body.r#type.is_empty() || link_body.r#type.len() == 0)
         {
@@ -348,7 +348,7 @@ impl LinkStore {
         match link_body.target {
             None => {}
             Some(Target::TargetFid(fid)) => {
-                key.extend_from_slice(&make_fid_key(fid as u32)[..Self::TARGET_ID_BYTE_SIZE])
+                key.extend_from_slice(&make_fid_key(fid)[..Self::TARGET_ID_BYTE_SIZE])
             }
         }
 
@@ -366,7 +366,7 @@ impl LinkStore {
                     .ok_or(HubError::invalid_parameter("invalid message data body"))
                     .and_then(|body_option| match body_option {
                         Body::LinkBody(link_body) => {
-                            Self::link_add_key(data.fid as u32, link_body, padded)
+                            Self::link_add_key(data.fid, link_body, padded)
                         }
                         _ => Err(HubError::invalid_parameter("link body not specified")),
                     })
@@ -384,7 +384,7 @@ impl LinkStore {
                     .ok_or(HubError::invalid_parameter("invalid message data body"))
                     .and_then(|body_option| match body_option {
                         Body::LinkBody(link_body) => {
-                            Self::link_remove_key(data.fid as u32, link_body, padded)
+                            Self::link_remove_key(data.fid, link_body, padded)
                         }
                         _ => Err(HubError::invalid_parameter("link body not specified")),
                     })
@@ -400,7 +400,7 @@ impl LinkStore {
     /// * `ts_hash` - the timestamp hash of the link message
     fn links_by_target_key(
         target: &Target,
-        fid: u32,
+        fid: u64,
         ts_hash: Option<&[u8; TS_HASH_LENGTH]>,
     ) -> Result<Vec<u8>, HubError> {
         if fid != 0 && (ts_hash.is_none() || ts_hash.is_some_and(|tsh| tsh.len() == 0)) {
@@ -424,7 +424,7 @@ impl LinkStore {
 
         key.push(RootPrefix::LinksByTarget as u8);
         let Target::TargetFid(target_fid) = target;
-        key.extend(make_fid_key(*target_fid as u32));
+        key.extend(make_fid_key(*target_fid));
 
         match ts_hash {
             Some(timestamp_hash) => {
@@ -460,14 +460,10 @@ impl LinkStore {
                                 .as_ref()
                                 .ok_or(HubError::invalid_parameter("target ID not specified"))
                                 .and_then(|target| {
-                                    LinkStore::links_by_target_key(
-                                        target,
-                                        data.fid as u32,
-                                        Some(ts_hash),
-                                    )
-                                    .and_then(|target_key| {
-                                        Ok((target_key, link_body.r#type.as_bytes().to_vec()))
-                                    })
+                                    LinkStore::links_by_target_key(target, data.fid, Some(ts_hash))
+                                        .and_then(|target_key| {
+                                            Ok((target_key, link_body.r#type.as_bytes().to_vec()))
+                                        })
                                 });
                         }
                         _ => Err(HubError::invalid_parameter("link body not specified")),
@@ -477,7 +473,7 @@ impl LinkStore {
 
     pub fn get_link_removes_by_fid(
         store: &Store<LinkStore>,
-        fid: u32,
+        fid: u64,
         r#type: String,
         page_options: &PageOptions,
     ) -> Result<MessagesPage, HubError> {
@@ -627,7 +623,7 @@ impl StoreDef for LinkStore {
             // Remove message and delete it as part of the RocksDB transaction
             let maybe_existing_remove = get_message(
                 &db,
-                message.data.as_ref().unwrap().fid as u32,
+                message.data.as_ref().unwrap().fid,
                 self.postfix(),
                 &vec_to_u8_24(&remove_ts_hash)?,
             )?;
@@ -671,7 +667,7 @@ impl StoreDef for LinkStore {
             // Add message and delete it as part of the RocksDB transaction
             let maybe_existing_add = get_message(
                 &db,
-                message.data.as_ref().unwrap().fid as u32,
+                message.data.as_ref().unwrap().fid,
                 self.postfix(),
                 &vec_to_u8_24(&add_ts_hash)?,
             )?;
@@ -714,13 +710,10 @@ impl StoreDef for LinkStore {
                     .ok_or(HubError::invalid_parameter("invalid message data body"))
                     .and_then(|body_option| match body_option {
                         Body::LinkCompactStateBody(link_compact_body) => {
-                            Self::link_compact_state_add_key(
-                                data.fid as u32,
-                                &link_compact_body.r#type,
-                            )
+                            Self::link_compact_state_add_key(data.fid, &link_compact_body.r#type)
                         }
                         Body::LinkBody(link_body) => {
-                            Self::link_compact_state_add_key(data.fid as u32, &link_body.r#type)
+                            Self::link_compact_state_add_key(data.fid, &link_body.r#type)
                         }
                         _ => Err(HubError::invalid_parameter(
                             "link_compact_body not specified",
@@ -729,7 +722,7 @@ impl StoreDef for LinkStore {
             })
     }
 
-    fn make_compact_state_prefix(&self, fid: u32) -> Result<Vec<u8>, HubError> {
+    fn make_compact_state_prefix(&self, fid: u64) -> Result<Vec<u8>, HubError> {
         let mut prefix =
             Vec::with_capacity(Self::ROOT_PREFIXED_FID_BYTE_SIZE + Self::POSTFIX_BYTE_SIZE);
 

--- a/src/storage/store/account/link_store.rs
+++ b/src/storage/store/account/link_store.rs
@@ -2,6 +2,7 @@ use tracing::warn;
 
 use super::{
     get_many_messages_as_bytes, get_message, make_fid_key, make_message_primary_key, make_user_key,
+    read_fid_key, read_ts_hash,
     store::{Store, StoreDef},
     MessagesPage, StoreEventHandler, PAGE_SIZE_MAX, TS_HASH_LENGTH,
 };
@@ -20,7 +21,7 @@ use crate::{
     proto::{Message, MessageType},
     storage::db::{RocksDB, RocksDbTransactionBatch},
 };
-use std::{borrow::Borrow, convert::TryInto, sync::Arc};
+use std::{borrow::Borrow, sync::Arc};
 
 /**
  * LinkStore persists Link Messages in RocksDB using a two-phase CRDT set to guarantee
@@ -162,13 +163,10 @@ impl LinkStore {
                     let ts_hash_offset = start_prefix.len();
                     let fid_offset: usize = ts_hash_offset + TS_HASH_LENGTH;
 
-                    let fid =
-                        u32::from_be_bytes(key[fid_offset..fid_offset + 4].try_into().unwrap());
-                    let ts_hash = key[ts_hash_offset..ts_hash_offset + TS_HASH_LENGTH]
-                        .try_into()
-                        .unwrap();
+                    let fid = read_fid_key(key, fid_offset);
+                    let ts_hash = read_ts_hash(key, ts_hash_offset);
                     let message_primary_key =
-                        make_message_primary_key(fid as u64, store.postfix(), Some(&ts_hash));
+                        make_message_primary_key(fid, store.postfix(), Some(&ts_hash));
 
                     message_keys.push(message_primary_key.to_vec());
                     if message_keys.len() >= page_options.page_size.unwrap_or(PAGE_SIZE_MAX) {

--- a/src/storage/store/account/message.rs
+++ b/src/storage/store/account/message.rs
@@ -1,5 +1,6 @@
 use super::PAGE_SIZE_MAX;
 use crate::core::error::HubError;
+use crate::core::types::Fid;
 use crate::storage::constants::{RootPrefix, UserPostfix};
 use crate::storage::db::{PageOptions, RocksdbError};
 use crate::storage::util::increment_vec_u8;
@@ -103,17 +104,18 @@ pub fn unpack_ts_hash(ts_hash: &[u8; TS_HASH_LENGTH]) -> (u32, [u8; HASH_LENGTH]
     (timestamp, hash)
 }
 
-pub fn make_fid_key(fid: u32) -> Vec<u8> {
-    fid.to_be_bytes().to_vec()
+pub fn make_fid_key(fid: u64) -> Vec<u8> {
+    // Downcast to u32, since on disk, we only assume 4 bytes for the fid to save space
+    (fid as Fid).to_be_bytes().to_vec()
 }
 
-pub fn read_fid_key(key: &[u8]) -> u32 {
+pub fn read_fid_key(key: &[u8]) -> u64 {
     let mut fid_bytes = [0u8; 4];
     fid_bytes.copy_from_slice(&key[0..4]);
-    u32::from_be_bytes(fid_bytes)
+    u32::from_be_bytes(fid_bytes) as u64
 }
 
-pub fn make_user_key(fid: u32) -> Vec<u8> {
+pub fn make_user_key(fid: u64) -> Vec<u8> {
     let mut key = Vec::with_capacity(1 + 4);
     key.push(RootPrefix::User as u8);
 
@@ -123,7 +125,7 @@ pub fn make_user_key(fid: u32) -> Vec<u8> {
 }
 
 pub fn make_message_primary_key(
-    fid: u32,
+    fid: u64,
     set: u8,
     ts_hash: Option<&[u8; TS_HASH_LENGTH]>,
 ) -> Vec<u8> {
@@ -139,7 +141,7 @@ pub fn make_message_primary_key(
 
 pub fn make_cast_id_key(cast_id: &CastId) -> Vec<u8> {
     let mut key = Vec::with_capacity(4 + HASH_LENGTH);
-    key.extend_from_slice(&make_fid_key(cast_id.fid as u32));
+    key.extend_from_slice(&make_fid_key(cast_id.fid));
     key.extend_from_slice(&cast_id.hash);
 
     key
@@ -147,7 +149,7 @@ pub fn make_cast_id_key(cast_id: &CastId) -> Vec<u8> {
 
 pub fn get_message(
     db: &RocksDB,
-    fid: u32,
+    fid: u64,
     set: u8,
     ts_hash: &[u8; TS_HASH_LENGTH],
 ) -> Result<Option<MessageProto>, HubError> {
@@ -269,7 +271,7 @@ pub fn put_message_transaction(
     let ts_hash = make_ts_hash(message.data.as_ref().unwrap().timestamp, &message.hash)?;
 
     let primary_key = make_message_primary_key(
-        message.data.as_ref().unwrap().fid as u32,
+        message.data.as_ref().unwrap().fid,
         type_to_set_postfix(MessageType::try_from(message.data.as_ref().unwrap().r#type).unwrap())
             as u8,
         Some(&ts_hash),
@@ -286,7 +288,7 @@ pub fn delete_message_transaction(
     let ts_hash = make_ts_hash(message.data.as_ref().unwrap().timestamp, &message.hash)?;
 
     let primary_key = make_message_primary_key(
-        message.data.as_ref().unwrap().fid as u32,
+        message.data.as_ref().unwrap().fid,
         type_to_set_postfix(MessageType::try_from(message.data.as_ref().unwrap().r#type).unwrap())
             as u8,
         Some(&ts_hash),

--- a/src/storage/store/account/message.rs
+++ b/src/storage/store/account/message.rs
@@ -1,6 +1,6 @@
 use super::PAGE_SIZE_MAX;
 use crate::core::error::HubError;
-use crate::core::types::Fid;
+use crate::core::types::FidOnDisk;
 use crate::storage::constants::{RootPrefix, UserPostfix};
 use crate::storage::db::{PageOptions, RocksdbError};
 use crate::storage::util::increment_vec_u8;
@@ -106,12 +106,12 @@ pub fn unpack_ts_hash(ts_hash: &[u8; TS_HASH_LENGTH]) -> (u32, [u8; HASH_LENGTH]
 
 pub fn make_fid_key(fid: u64) -> Vec<u8> {
     // Downcast to u32, since on disk, we only assume 4 bytes for the fid to save space
-    (fid as Fid).to_be_bytes().to_vec()
+    (fid as FidOnDisk).to_be_bytes().to_vec()
 }
 
 pub fn read_fid_key(key: &[u8], offset: usize) -> u64 {
-    let mut fid_bytes = [0u8; 4];
-    fid_bytes.copy_from_slice(&key[offset..offset + 4]);
+    let mut fid_bytes = [0u8; FID_BYTES];
+    fid_bytes.copy_from_slice(&key[offset..offset + FID_BYTES]);
     // Upcast to u64 so we are always dealing with the same type everywhere
     u32::from_be_bytes(fid_bytes) as u64
 }

--- a/src/storage/store/account/message.rs
+++ b/src/storage/store/account/message.rs
@@ -109,10 +109,17 @@ pub fn make_fid_key(fid: u64) -> Vec<u8> {
     (fid as Fid).to_be_bytes().to_vec()
 }
 
-pub fn read_fid_key(key: &[u8]) -> u64 {
+pub fn read_fid_key(key: &[u8], offset: usize) -> u64 {
     let mut fid_bytes = [0u8; 4];
-    fid_bytes.copy_from_slice(&key[0..4]);
+    fid_bytes.copy_from_slice(&key[offset..offset + 4]);
+    // Upcast to u64 so we are always dealing with the same type everywhere
     u32::from_be_bytes(fid_bytes) as u64
+}
+
+pub fn read_ts_hash(key: &[u8], offset: usize) -> [u8; TS_HASH_LENGTH] {
+    let mut ts_hash = [0u8; TS_HASH_LENGTH];
+    ts_hash.copy_from_slice(&key[offset..offset + TS_HASH_LENGTH]);
+    ts_hash
 }
 
 pub fn make_user_key(fid: u64) -> Vec<u8> {

--- a/src/storage/store/account/name_registry_events.rs
+++ b/src/storage/store/account/name_registry_events.rs
@@ -18,7 +18,7 @@ pub fn make_fname_username_proof_key(name: &[u8]) -> Vec<u8> {
     key
 }
 
-pub fn make_fname_username_proof_by_fid_key(fid: u32) -> Vec<u8> {
+pub fn make_fname_username_proof_by_fid_key(fid: u64) -> Vec<u8> {
     let mut key = Vec::with_capacity(1 + 4);
 
     key.push(RootPrefix::FNameUserNameProofByFid as u8);
@@ -42,7 +42,7 @@ pub fn get_username_proof(db: &RocksDB, name: &[u8]) -> Result<Option<UserNamePr
     }
 }
 
-pub fn get_fname_proof_by_fid(db: &RocksDB, fid: u32) -> Result<Option<UserNameProof>, HubError> {
+pub fn get_fname_proof_by_fid(db: &RocksDB, fid: u64) -> Result<Option<UserNameProof>, HubError> {
     let secondary_key = make_fname_username_proof_by_fid_key(fid);
     let primary_key = db.get(&secondary_key)?;
     if primary_key.is_none() {
@@ -72,14 +72,14 @@ pub fn put_username_proof_transaction(
     let primary_key = make_fname_username_proof_key(&username_proof.name);
     txn.put(primary_key.clone(), buf);
 
-    let secondary_key = make_fname_username_proof_by_fid_key(username_proof.fid as u32);
+    let secondary_key = make_fname_username_proof_by_fid_key(username_proof.fid);
     txn.put(secondary_key, primary_key);
 }
 
 pub fn delete_username_proof_transaction(
     txn: &mut RocksDbTransactionBatch,
     username_proof: &UserNameProof,
-    existing_fid: Option<u32>,
+    existing_fid: Option<u64>,
 ) {
     let buf = username_proof.encode_to_vec();
 

--- a/src/storage/store/account/reaction_store.rs
+++ b/src/storage/store/account/reaction_store.rs
@@ -120,7 +120,7 @@ impl StoreDef for ReactionStoreDef {
         };
 
         Self::make_reaction_adds_key(
-            message.data.as_ref().unwrap().fid as u32,
+            message.data.as_ref().unwrap().fid,
             reaction_body.r#type,
             reaction_body.target.as_ref(),
         )
@@ -138,7 +138,7 @@ impl StoreDef for ReactionStoreDef {
         };
 
         Self::make_reaction_removes_key(
-            message.data.as_ref().unwrap().fid as u32,
+            message.data.as_ref().unwrap().fid,
             reaction_body.r#type,
             reaction_body.target.as_ref(),
         )
@@ -151,7 +151,7 @@ impl StoreDef for ReactionStoreDef {
         })
     }
 
-    fn make_compact_state_prefix(&self, _fid: u32) -> Result<Vec<u8>, HubError> {
+    fn make_compact_state_prefix(&self, _fid: u64) -> Result<Vec<u8>, HubError> {
         Err(HubError {
             code: "bad_request.invalid_param".to_string(),
             message: "Reaction Store doesn't support compact state".to_string(),
@@ -184,7 +184,7 @@ impl ReactionStoreDef {
 
         let by_target_key = ReactionStoreDef::make_reactions_by_target_key(
             target,
-            message.data.as_ref().unwrap().fid as u32,
+            message.data.as_ref().unwrap().fid,
             Some(ts_hash),
         );
 
@@ -193,7 +193,7 @@ impl ReactionStoreDef {
 
     pub fn make_reactions_by_target_key(
         target: &Target,
-        fid: u32,
+        fid: u64,
         ts_hash: Option<&[u8; TS_HASH_LENGTH]>,
     ) -> Vec<u8> {
         let mut key = Vec::with_capacity(1 + 28 + 24 + 4);
@@ -218,7 +218,7 @@ impl ReactionStoreDef {
     }
 
     pub fn make_reaction_adds_key(
-        fid: u32,
+        fid: u64,
         r#type: i32,
         target: Option<&Target>,
     ) -> Result<Vec<u8>, HubError> {
@@ -244,7 +244,7 @@ impl ReactionStoreDef {
     }
 
     pub fn make_reaction_removes_key(
-        fid: u32,
+        fid: u64,
         r#type: i32,
         target: Option<&Target>,
     ) -> Result<Vec<u8>, HubError> {
@@ -287,13 +287,13 @@ impl ReactionStore {
 
     pub fn get_reaction_add(
         store: &Store<ReactionStoreDef>,
-        fid: u32,
+        fid: u64,
         r#type: i32,
         target: Option<Target>,
     ) -> Result<Option<Message>, HubError> {
         let partial_message = Message {
             data: Some(MessageData {
-                fid: fid as u64,
+                fid,
                 r#type: MessageType::ReactionAdd.into(),
                 body: Some(Body::ReactionBody(ReactionBody {
                     r#type,
@@ -309,13 +309,13 @@ impl ReactionStore {
 
     pub fn get_reaction_remove(
         store: &Store<ReactionStoreDef>,
-        fid: u32,
+        fid: u64,
         r#type: i32,
         target: Option<Target>,
     ) -> Result<Option<Message>, HubError> {
         let partial_message = Message {
             data: Some(MessageData {
-                fid: fid as u64,
+                fid,
                 r#type: MessageType::ReactionRemove.into(),
                 body: Some(Body::ReactionBody(ReactionBody {
                     r#type,
@@ -334,7 +334,7 @@ impl ReactionStore {
 
     pub fn get_reaction_adds_by_fid(
         store: &Store<ReactionStoreDef>,
-        fid: u32,
+        fid: u64,
         reaction_type: i32,
         page_options: &PageOptions,
     ) -> Result<MessagesPage, HubError> {
@@ -357,7 +357,7 @@ impl ReactionStore {
 
     pub fn get_reaction_removes_by_fid(
         store: &Store<ReactionStoreDef>,
-        fid: u32,
+        fid: u64,
         reaction_type: i32,
         page_options: &PageOptions,
     ) -> Result<MessagesPage, HubError> {
@@ -406,7 +406,7 @@ impl ReactionStore {
                         .try_into()
                         .unwrap();
                     let message_primary_key =
-                        make_message_primary_key(fid, store.postfix(), Some(&ts_hash));
+                        make_message_primary_key(fid as u64, store.postfix(), Some(&ts_hash));
 
                     message_keys.push(message_primary_key.to_vec());
                     if message_keys.len() >= page_options.page_size.unwrap_or(PAGE_SIZE_MAX) {

--- a/src/storage/store/account/username_proof_store.rs
+++ b/src/storage/store/account/username_proof_store.rs
@@ -58,7 +58,7 @@ impl StoreDef for UsernameProofStoreDef {
         };
 
         Ok(Self::make_username_proof_by_fid_key(
-            message.data.as_ref().unwrap().fid as u32,
+            message.data.as_ref().unwrap().fid,
             name,
         ))
     }
@@ -89,7 +89,7 @@ impl StoreDef for UsernameProofStoreDef {
         })
     }
 
-    fn make_compact_state_prefix(&self, _fid: u32) -> Result<Vec<u8>, HubError> {
+    fn make_compact_state_prefix(&self, _fid: u64) -> Result<Vec<u8>, HubError> {
         Err(HubError {
             code: "bad_request.invalid_param".to_string(),
             message: "Username Proof Store doesn't support compact state".to_string(),
@@ -128,7 +128,7 @@ impl StoreDef for UsernameProofStoreDef {
             let by_name_key = Self::make_username_proof_by_name_key(&body.name);
             txn.put(
                 by_name_key,
-                make_fid_key(message.data.as_ref().unwrap().fid as u32),
+                make_fid_key(message.data.as_ref().unwrap().fid),
             );
             Ok(())
         } else {
@@ -354,7 +354,7 @@ impl UsernameProofStoreDef {
         key
     }
 
-    fn make_username_proof_by_fid_key(fid: u32, name: &Vec<u8>) -> Vec<u8> {
+    fn make_username_proof_by_fid_key(fid: u64, name: &Vec<u8>) -> Vec<u8> {
         let mut key = Vec::with_capacity(1 + 4 + 1 + name.len());
 
         key.extend_from_slice(&make_user_key(fid));
@@ -410,7 +410,7 @@ impl UsernameProofStore {
         let fid = read_fid_key(&fid_result.unwrap());
         let partial_message = Message {
             data: Some(proto::MessageData {
-                fid: fid as u64,
+                fid,
                 body: Some(Body::UsernameProofBody(proto::UserNameProof {
                     name: name.clone(),
                     ..Default::default()
@@ -425,7 +425,7 @@ impl UsernameProofStore {
 
     pub fn get_username_proofs_by_fid(
         store: &Store<UsernameProofStoreDef>,
-        fid: u32,
+        fid: u64,
         page_options: &PageOptions,
     ) -> Result<MessagesPage, HubError> {
         store.get_adds_by_fid::<fn(&Message) -> bool>(fid, page_options, None)
@@ -434,11 +434,11 @@ impl UsernameProofStore {
     pub fn get_username_proof_by_fid_and_name(
         store: &Store<UsernameProofStoreDef>,
         name: &Vec<u8>,
-        fid: u32,
+        fid: u64,
     ) -> Result<Option<Message>, HubError> {
         let partial_message = Message {
             data: Some(proto::MessageData {
-                fid: fid as u64,
+                fid,
                 body: Some(Body::UsernameProofBody(proto::UserNameProof {
                     name: name.clone(),
                     ..Default::default()

--- a/src/storage/store/account/username_proof_store.rs
+++ b/src/storage/store/account/username_proof_store.rs
@@ -209,7 +209,7 @@ impl StoreDef for UsernameProofStoreDef {
 
         let fid_result = db.get(by_name_key.as_slice());
         if let Ok(Some(fid_bytes)) = fid_result {
-            let fid = read_fid_key(&fid_bytes);
+            let fid = read_fid_key(&fid_bytes, 0);
             if fid > 0 {
                 let existing_add_key = Self::make_username_proof_by_fid_key(fid, name);
                 if let Ok(existing_message_ts_hash) = db.get(existing_add_key.as_slice()) {
@@ -407,7 +407,7 @@ impl UsernameProofStore {
             });
         }
 
-        let fid = read_fid_key(&fid_result.unwrap());
+        let fid = read_fid_key(&fid_result.unwrap(), 0);
         let partial_message = Message {
             data: Some(proto::MessageData {
                 fid,

--- a/src/storage/store/account/verification_store.rs
+++ b/src/storage/store/account/verification_store.rs
@@ -366,7 +366,7 @@ impl VerificationStore {
                     };
 
                     if existing_fid_res.is_ok() {
-                        let existing_fid = read_fid_key(&existing_fid_res.unwrap());
+                        let existing_fid = read_fid_key(&existing_fid_res.unwrap(), 0);
                         let existing_message =
                             match Self::get_verification_add(store, existing_fid, address) {
                                 Ok(Some(message)) => message,

--- a/src/storage/store/engine_tests.rs
+++ b/src/storage/store/engine_tests.rs
@@ -948,7 +948,7 @@ mod tests {
         ));
         let proof = engine.get_fname_proof(fname).unwrap();
         assert!(proof.is_some());
-        assert_eq!(proof.unwrap().fid as u32, FID_FOR_TEST);
+        assert_eq!(proof.unwrap().fid, FID_FOR_TEST);
     }
 
     #[tokio::test]

--- a/src/storage/store/stores.rs
+++ b/src/storage/store/stores.rs
@@ -154,7 +154,7 @@ impl Stores {
 
     pub fn get_usage(
         &self,
-        fid: u32,
+        fid: u64,
         message_type: MessageType,
         txn_batch: &mut RocksDbTransactionBatch,
     ) -> Result<(u32, u32), StoresError> {
@@ -176,7 +176,7 @@ impl Stores {
 
     pub fn revoke_messages(
         &self,
-        fid: u32,
+        fid: u64,
         key: &Vec<u8>,
         txn_batch: &mut RocksDbTransactionBatch,
     ) -> Result<Vec<HubEvent>, StoresError> {

--- a/src/storage/store/test_helper.rs
+++ b/src/storage/store/test_helper.rs
@@ -17,10 +17,10 @@ use crate::storage::trie::merkle_trie::TrieKey;
 use crate::utils::factory::{events_factory, username_factory};
 use hex::FromHex;
 
-pub const FID_FOR_TEST: u32 = 1234;
+pub const FID_FOR_TEST: u64 = 1234;
 
 #[cfg(test)]
-pub const FID2_FOR_TEST: u32 = 1235;
+pub const FID2_FOR_TEST: u64 = 1235;
 
 pub mod limits {
     use crate::storage::store::stores::Limits;
@@ -194,11 +194,11 @@ pub fn validate_and_commit_state_change(
     chunk
 }
 
-pub fn default_storage_event(fid: u32) -> OnChainEvent {
+pub fn default_storage_event(fid: u64) -> OnChainEvent {
     events_factory::create_rent_event(fid, None, Some(1), false)
 }
 
-pub async fn register_user(fid: u32, signer: SigningKey, engine: &mut ShardEngine) {
+pub async fn register_user(fid: u64, signer: SigningKey, engine: &mut ShardEngine) {
     commit_event(engine, &default_storage_event(fid)).await;
     let id_register_event =
         events_factory::create_id_register_event(fid, proto::IdRegisterEventType::Register);
@@ -210,7 +210,7 @@ pub async fn register_user(fid: u32, signer: SigningKey, engine: &mut ShardEngin
 
 #[cfg(test)]
 pub async fn register_fname(
-    fid: u32,
+    fid: u64,
     username: &String,
     timestamp: Option<u64>,
     engine: &mut ShardEngine,

--- a/src/utils/cli.rs
+++ b/src/utils/cli.rs
@@ -34,12 +34,12 @@ pub async fn send_on_chain_event(
     Ok(response.into_inner())
 }
 
-pub fn compose_rent_event(fid: u32) -> OnChainEvent {
+pub fn compose_rent_event(fid: u64) -> OnChainEvent {
     factory::events_factory::create_rent_event(fid, None, Some(10), false)
 }
 
 pub fn compose_message(
-    fid: u32,
+    fid: u64,
     text: &str,
     timestamp: Option<u32>,
     private_key: Option<&SigningKey>,

--- a/src/utils/factory.rs
+++ b/src/utils/factory.rs
@@ -35,7 +35,7 @@ pub mod events_factory {
     use super::*;
     use crate::proto;
 
-    pub fn create_onchain_event(fid: u32) -> OnChainEvent {
+    pub fn create_onchain_event(fid: u64) -> OnChainEvent {
         OnChainEvent {
             r#type: OnChainEventType::EventTypeIdRegister as i32,
             chain_id: 10,
@@ -44,7 +44,7 @@ pub mod events_factory {
             block_timestamp: 0,
             transaction_hash: rand::random::<[u8; 32]>().to_vec(),
             log_index: 0,
-            fid: fid as u64,
+            fid,
             tx_index: 0,
             version: 1,
             body: None,
@@ -52,7 +52,7 @@ pub mod events_factory {
     }
 
     pub fn create_rent_event(
-        fid: u32,
+        fid: u64,
         legacy_units: Option<u32>,
         units: Option<u32>,
         expired: bool,
@@ -96,7 +96,7 @@ pub mod events_factory {
             block_timestamp: timestamp as u64,
             transaction_hash: rand::random::<[u8; 32]>().to_vec(),
             log_index: 0,
-            fid: fid as u64,
+            fid,
             tx_index: 0,
             version: 1,
             body: Some(proto::on_chain_event::Body::StorageRentEventBody(
@@ -106,7 +106,7 @@ pub mod events_factory {
     }
 
     pub fn create_signer_event(
-        fid: u32,
+        fid: u64,
         signer: SigningKey,
         event_type: proto::SignerEventType,
     ) -> OnChainEvent {
@@ -125,7 +125,7 @@ pub mod events_factory {
             block_timestamp: time::current_timestamp_with_offset(-10) as u64,
             transaction_hash: rand::random::<[u8; 32]>().to_vec(),
             log_index: 0,
-            fid: fid as u64,
+            fid,
             tx_index: 0,
             version: 1,
             body: Some(proto::on_chain_event::Body::SignerEventBody(
@@ -135,7 +135,7 @@ pub mod events_factory {
     }
 
     pub fn create_id_register_event(
-        fid: u32,
+        fid: u64,
         event_type: proto::IdRegisterEventType,
     ) -> OnChainEvent {
         let id_register_event_body = proto::IdRegisterEventBody {
@@ -152,7 +152,7 @@ pub mod events_factory {
             block_timestamp: time::current_timestamp_with_offset(-10) as u64,
             transaction_hash: rand::random::<[u8; 32]>().to_vec(),
             log_index: 0,
-            fid: fid as u64,
+            fid,
             tx_index: 0,
             version: 1,
             body: Some(proto::on_chain_event::Body::IdRegisterEventBody(
@@ -174,7 +174,7 @@ pub mod messages_factory {
     }
 
     pub fn create_message_with_data(
-        fid: u32,
+        fid: u64,
         msg_type: MessageType,
         body: message::message_data::Body,
         timestamp: Option<u32>,
@@ -194,7 +194,7 @@ pub mod messages_factory {
         let timestamp = timestamp.unwrap_or_else(|| farcaster_time());
 
         let msg_data = MessageData {
-            fid: fid as u64,
+            fid,
             r#type: msg_type as i32,
             timestamp,
             network: network as i32,
@@ -221,7 +221,7 @@ pub mod messages_factory {
         use crate::proto::CastRemoveBody;
 
         pub fn create_cast_add(
-            fid: u32,
+            fid: u64,
             text: &str,
             timestamp: Option<u32>,
             private_key: Option<&SigningKey>,
@@ -245,7 +245,7 @@ pub mod messages_factory {
         }
 
         pub fn create_cast_remove(
-            fid: u32,
+            fid: u64,
             target_hash: &Vec<u8>,
             timestamp: Option<u32>,
             private_key: Option<&SigningKey>,
@@ -269,16 +269,16 @@ pub mod messages_factory {
         use super::*;
 
         pub fn create_link_add(
-            fid: u32,
+            fid: u64,
             link_type: String,
-            target_fid: u32,
+            target_fid: u64,
             timestamp: Option<u32>,
             private_key: Option<&SigningKey>,
         ) -> message::Message {
             let link_body = LinkBody {
                 r#type: link_type,
                 display_timestamp: None,
-                target: Some(Target::TargetFid(target_fid as u64)),
+                target: Some(Target::TargetFid(target_fid)),
             };
             create_message_with_data(
                 fid,
@@ -290,16 +290,16 @@ pub mod messages_factory {
         }
 
         pub fn create_link_remove(
-            fid: u32,
+            fid: u64,
             link_type: String,
-            target_fid: u32,
+            target_fid: u64,
             timestamp: Option<u32>,
             private_key: Option<&SigningKey>,
         ) -> crate::proto::Message {
             let link_body = LinkBody {
                 r#type: link_type,
                 display_timestamp: None,
-                target: Some(Target::TargetFid(target_fid as u64)),
+                target: Some(Target::TargetFid(target_fid)),
             };
             create_message_with_data(
                 fid,
@@ -311,15 +311,15 @@ pub mod messages_factory {
         }
 
         pub fn create_link_compact_state(
-            fid: u32,
+            fid: u64,
             link_type: String,
-            target_fid: u32,
+            target_fid: u64,
             timestamp: Option<u32>,
             private_key: Option<&SigningKey>,
         ) -> crate::proto::Message {
             let link_compact_state_body = LinkCompactStateBody {
                 r#type: link_type,
-                target_fids: vec![target_fid as u64],
+                target_fids: vec![target_fid],
             };
 
             create_message_with_data(
@@ -338,7 +338,7 @@ pub mod messages_factory {
         use super::*;
 
         pub fn create_reaction_add(
-            fid: u32,
+            fid: u64,
             reaction_type: ReactionType,
             target_url: String,
             timestamp: Option<u32>,
@@ -358,7 +358,7 @@ pub mod messages_factory {
         }
 
         pub fn create_reaction_remove(
-            fid: u32,
+            fid: u64,
             reaction_type: ReactionType,
             target_url: String,
             timestamp: Option<u32>,
@@ -383,7 +383,7 @@ pub mod messages_factory {
         use super::*;
 
         pub fn create_user_data_add(
-            fid: u32,
+            fid: u64,
             user_data_type: UserDataType,
             value: &String,
             timestamp: Option<u32>,
@@ -409,7 +409,7 @@ pub mod messages_factory {
         use super::*;
 
         pub fn create_verification_add(
-            fid: u32,
+            fid: u64,
             verification_type: u32,
             address: String,
             claim_signature: String,
@@ -435,7 +435,7 @@ pub mod messages_factory {
         }
 
         pub fn create_verification_remove(
-            fid: u32,
+            fid: u64,
             address: String,
             timestamp: Option<u32>,
             private_key: Option<&SigningKey>,
@@ -477,7 +477,7 @@ pub mod messages_factory {
             };
 
             create_message_with_data(
-                fid as u32,
+                fid,
                 MessageType::UsernameProof,
                 message::message_data::Body::UsernameProofBody(proof),
                 Some(timestamp as u32),
@@ -509,16 +509,16 @@ pub mod username_factory {
     }
 
     pub fn create_transfer(
-        fid: u32,
+        fid: u64,
         name: &String,
         timestamp: Option<u64>,
-        from_fid: Option<u32>,
+        from_fid: Option<u64>,
     ) -> FnameTransfer {
         FnameTransfer {
             id: rand::random::<u64>(),
-            from_fid: from_fid.unwrap_or_else(|| 0) as u64,
+            from_fid: from_fid.unwrap_or_else(|| 0),
             proof: Some(create_username_proof(
-                fid as u64,
+                fid,
                 crate::proto::UserNameType::UsernameTypeFname,
                 name,
                 timestamp,


### PR DESCRIPTION
We were converting fids from u64 to u32 and back all over. Now we use u64 everywhere, except right before writing to the db and right after reading from it.

The original reason to use u32 was to save on disk space, this preserves the space savings but it's cleaner to deal with u64 everywhere.