### PR TITLE
make store type names consistent with hubs

### DIFF
--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -426,7 +426,7 @@ mod tests {
             (configured_limits.limits.casts * 2) + (configured_limits.legacy_limits.casts)
         );
         assert_eq!(casts_limit.used, 2); // Cast remove counts as 1
-        assert_eq!(casts_limit.name, "STORE_TYPE_CASTS");
+        assert_eq!(casts_limit.name, "CASTS");
 
         let links_limit = response
             .get_ref()

--- a/src/storage/store/stores.rs
+++ b/src/storage/store/stores.rs
@@ -248,9 +248,18 @@ impl Stores {
             let max_messages =
                 self.store_limits
                     .max_messages(slot.units, slot.legacy_units, store_type);
+            let name = match store_type {
+                StoreType::None => "NONE",
+                StoreType::Casts => "CASTS",
+                StoreType::Links => "LINKS",
+                StoreType::Reactions => "REACTIONS",
+                StoreType::UserData => "USER_DATA",
+                StoreType::Verifications => "VERIFICATIONS",
+                StoreType::UsernameProofs => "USERNAME_PROOFS",
+            };
             let limit = StorageLimit {
                 store_type: store_type.try_into().unwrap(),
-                name: store_type.as_str_name().to_string(),
+                name: name.to_string(),
                 limit: max_messages as u64,
                 used: used as u64,
                 earliest_timestamp: 0, // Deprecate?


### PR DESCRIPTION
The `StoreType` names in hubs don't have the `STORE_TYPE` prefix. Manually translate the enum to strings to match hubs. 