### PR TITLE
fix prefix for fname trie key

### DIFF
--- a/src/storage/trie/merkle_trie.rs
+++ b/src/storage/trie/merkle_trie.rs
@@ -40,7 +40,7 @@ impl TrieKey {
     pub fn for_fname(fid: u64, name: &String) -> Vec<u8> {
         let mut key = Vec::new();
         key.extend_from_slice(&Self::for_fid(fid));
-        key.push(8); // 1-7 is for onchain events, use 8 for fnames, and everything else for messages
+        key.push(7); // 1-6 is for onchain events, use 7 for fnames, and everything else for messages
         key.extend_from_slice(&name.as_bytes());
         key
     }


### PR DESCRIPTION
Use a prefix of 7 rather than 8 for fnames. This ensures we don't overlap with message type prefixes. 