### PR TITLE
turbohash

### DIFF
--- a/src/perf/trie_only_perftest.rs
+++ b/src/perf/trie_only_perftest.rs
@@ -32,7 +32,7 @@ struct Args {
 
 pub fn run() -> Result<(), Box<dyn Error>> {
     let args = Args::parse();
-    let turbohash = 0;
+    let turbohash = 1;
 
     let host = ("127.0.0.1", cadence::DEFAULT_PORT);
     let socket = net::UdpSocket::bind("0.0.0.0:0").unwrap();

--- a/src/proto/sync_trie.proto
+++ b/src/proto/sync_trie.proto
@@ -4,6 +4,6 @@ message DbTrieNode {
   bytes key = 1;
   repeated uint32 childChars = 2;
   uint32 items = 3;
-  bytes hash = 4;
+  map<uint32, bytes> childHashes = 4;
 }
 

--- a/src/storage/trie/merkle_trie.rs
+++ b/src/storage/trie/merkle_trie.rs
@@ -155,7 +155,11 @@ impl MerkleTrie {
 
         if let Some(root) = self.root.as_mut() {
             let mut txn = RocksDbTransactionBatch::new();
-            let results = root.insert(ctx, db, &mut txn, keys, 0)?;
+            // root_stub_map: the hash of a node is stored/cached in the parent of that node (in a hashmap)
+            // the root doesn't have a parent, but still needs a hashmap here to satisfy the API. Note also
+            // that the root's hash will NOT be populated anywhere in this map. Use root.hash() for that.
+            let mut root_stub_map = HashMap::new();
+            let results = root.insert(ctx, &mut root_stub_map, db, &mut txn, keys, 0)?;
 
             txn_batch.merge(txn);
             Ok(results)
@@ -185,7 +189,9 @@ impl MerkleTrie {
 
         if let Some(root) = self.root.as_mut() {
             let mut txn = RocksDbTransactionBatch::new();
-            let results = root.delete(ctx, db, &mut txn, keys, 0)?;
+            // root_stub_map: see comment in insert()
+            let root_stub_map = &mut HashMap::new();
+            let results = root.delete(ctx, root_stub_map, db, &mut txn, keys, 0)?;
 
             txn_batch.merge(txn);
             Ok(results)


### PR DESCRIPTION
This change stores the hash of a trie node in the node's parent (in a hashmap).

This yields an important performance improvement when recomputing the hash of a changed node. Previously, when recomputing the hash, as we are working our way up the trie, we had to load siblings of a changed node out of the db. In this version, the sibling hashes are already loaded, which dramatically reduces the number of db reads.