### PR TITLE
pin foundry dependency to a rev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2315,7 +2315,7 @@ dependencies = [
 [[package]]
 name = "foundry-common"
 version = "0.2.0"
-source = "git+https://github.com/foundry-rs/foundry#6b07c77eb1c1d1c4b56ffa7f79240254b73236d2"
+source = "git+https://github.com/foundry-rs/foundry?rev=6b07c77eb1c1d1c4b56ffa7f79240254b73236d2#6b07c77eb1c1d1c4b56ffa7f79240254b73236d2"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -2365,7 +2365,7 @@ dependencies = [
 [[package]]
 name = "foundry-common-fmt"
 version = "0.2.0"
-source = "git+https://github.com/foundry-rs/foundry#6b07c77eb1c1d1c4b56ffa7f79240254b73236d2"
+source = "git+https://github.com/foundry-rs/foundry?rev=6b07c77eb1c1d1c4b56ffa7f79240254b73236d2#6b07c77eb1c1d1c4b56ffa7f79240254b73236d2"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -2483,7 +2483,7 @@ dependencies = [
 [[package]]
 name = "foundry-config"
 version = "0.2.0"
-source = "git+https://github.com/foundry-rs/foundry#6b07c77eb1c1d1c4b56ffa7f79240254b73236d2"
+source = "git+https://github.com/foundry-rs/foundry?rev=6b07c77eb1c1d1c4b56ffa7f79240254b73236d2#6b07c77eb1c1d1c4b56ffa7f79240254b73236d2"
 dependencies = [
  "Inflector",
  "alloy-chains",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ humantime = "2.1.0"
 itertools = "0.13.0"
 cadence = "1.5.0"
 tempfile = "3.13.0"
-foundry-common = { git = "https://github.com/foundry-rs/foundry", version = "0.2.0" }
+foundry-common = { git = "https://github.com/foundry-rs/foundry", rev="6b07c77eb1c1d1c4b56ffa7f79240254b73236d2" }
 
 [build-dependencies]
 tonic-build = "0.9.2"


### PR DESCRIPTION
The 0.2.0 tag was removed when 0.3.0 was introduced. Remove the version and pin the dependency to a rev. 