### PR TITLE
ingest real onchain events

### DIFF
--- a/src/bin/setup_local_testnet.rs
+++ b/src/bin/setup_local_testnet.rs
@@ -12,6 +12,15 @@ struct Args {
     #[arg(long, default_value = "")]
     l1_rpc_url: String,
 
+    #[arg(long, default_value = "")]
+    l2_rpc_url: String,
+
+    #[arg(long, default_value = "108864739")]
+    start_block_number: u64,
+
+    #[arg(long, default_value = "0")]
+    stop_block_number: u64,
+
     /// Statsd prefix. note: node ID will be appended before config file written
     #[arg(long, default_value = "snapchain")]
     statsd_prefix: String,
@@ -55,12 +64,12 @@ async fn main() {
         let secret_key = hex::encode(SecretKey::generate());
         let rpc_port = base_rpc_port + i;
         let gossip_port = base_gossip_port + i;
-        let host = format!("127.0.0.1{i}");
+        let host = format!("127.0.0.1");
         let rpc_address = format!("{host}:{rpc_port}");
         let gossip_multi_addr = format!("/ip4/{host}/udp/{gossip_port}/quic-v1");
         let other_nodes_addresses = (1..=nodes)
             .filter(|&x| x != id)
-            .map(|x| format!("/ip4/127.0.0.1{x}/udp/{:?}/quic-v1", base_gossip_port + x))
+            .map(|x| format!("/ip4/127.0.0.1/udp/{:?}/quic-v1", base_gossip_port + x))
             .collect::<Vec<String>>()
             .join(",");
 
@@ -70,6 +79,9 @@ async fn main() {
         let statsd_addr = args.statsd_addr.clone();
         let statsd_use_tags = args.statsd_use_tags;
         let l1_rpc_url = args.l1_rpc_url.clone();
+        let l2_rpc_url = args.l2_rpc_url.clone();
+        let start_block_number = args.start_block_number;
+        let stop_block_number = args.stop_block_number;
 
         let config_file_content = format!(
             r#"
@@ -89,6 +101,11 @@ bootstrap_peers = "{other_nodes_addresses}"
 [consensus]
 private_key = "{secret_key}"
 propose_value_delay = "{propose_value_delay}"
+
+[onchain_events]
+rpc_url= "{l2_rpc_url}"
+start_block_number = {start_block_number}
+stop_block_number = {stop_block_number}
             "#
         );
 

--- a/src/connectors/onchain_events/mod.rs
+++ b/src/connectors/onchain_events/mod.rs
@@ -306,7 +306,7 @@ impl Subscriber {
                         event_type: IdRegisterEventType::Register as i32,
                         to: to.to_vec(),
                         recovery_address: recovery.to_vec(),
-                        from: vec![], // TODO(aditi) : What to do about this?
+                        from: vec![],
                     }),
                 )
                 .await;

--- a/src/connectors/onchain_events/mod.rs
+++ b/src/connectors/onchain_events/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use alloy_primitives::{address, Address, Bytes, FixedBytes, Uint};
+use alloy_primitives::{address, Address, FixedBytes, Uint};
 use alloy_provider::{Provider, ProviderBuilder, RootProvider};
 use alloy_rpc_types::{Filter, Log};
 use alloy_sol_types::{sol, SolEvent};
@@ -11,6 +11,16 @@ use futures_util::stream::StreamExt;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::{error, info};
+
+use crate::{
+    mempool::routing::MessageRouter,
+    proto::{
+        on_chain_event, IdRegisterEventBody, IdRegisterEventType, OnChainEvent, OnChainEventType,
+        SignerEventBody, SignerEventType, SignerMigratedEventBody, StorageRentEventBody,
+        ValidatorMessage,
+    },
+    storage::store::engine::{MempoolMessage, Senders},
+};
 
 sol!(
     #[allow(missing_docs)]
@@ -39,18 +49,23 @@ static KEY_REGISTRY: Address = address!("00000000Fc1237824fb747aBDE0FF18990E59b7
 
 static ID_REGISTRY: Address = address!("00000000Fc6c5F01Fc30151999387Bb99A9f489b");
 
-static CHAIN_ID: u64 = 10; // OP mainnet
+static CHAIN_ID: u32 = 10; // OP mainnet
 const RENT_EXPIRY_IN_SECONDS: u64 = 365 * 24 * 60 * 60; // One year
+const FIRST_BLOCK: u64 = 108864739;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Config {
     pub rpc_url: String,
+    pub start_block_number: u64,
+    pub stop_block_number: u64,
 }
 
 impl Default for Config {
     fn default() -> Config {
         return Config {
             rpc_url: String::new(),
+            start_block_number: FIRST_BLOCK,
+            stop_block_number: FIRST_BLOCK,
         };
     }
 }
@@ -81,95 +96,11 @@ pub enum SubscribeError {
     #[error("Log missing tx index")]
     LogMissingTxIndex,
 
+    #[error("Log missing tx hash")]
+    LogMissingTransactionHash,
+
     #[error("Unable to find block by hash")]
     UnableToFindBlockByHash,
-}
-
-#[derive(Debug)]
-pub enum SignerEvent {
-    Add {
-        key: Bytes,
-        key_type: u32,
-        metadata: Bytes,
-        metadata_type: u8,
-    },
-    Remove {
-        key: Bytes,
-    },
-    AdminReset {
-        key: Bytes,
-    },
-}
-
-#[derive(Debug)]
-pub struct SignerMigratedEvent {
-    #[allow(dead_code)] // TODO
-    migrated_at: u64,
-}
-
-#[derive(Debug)]
-pub enum IdRegisterEvent {
-    Register {
-        to: Address,
-        recovery_address: Address,
-    },
-    Transfer {
-        from: Address,
-        to: Address,
-    },
-    ChangeRecovery {
-        recovery_address: Address,
-    },
-}
-
-#[derive(Debug)]
-pub struct StorageRentEvent {
-    #[allow(dead_code)] // TODO
-    payer: Address,
-
-    #[allow(dead_code)] // TODO
-    units: u64,
-
-    #[allow(dead_code)] // TODO
-    expiry: u64,
-}
-
-#[derive(Debug)]
-pub enum EventType {
-    Signer(SignerEvent),
-    SignerMigrated { migrated_at: u64 },
-    IdRegister(IdRegisterEvent),
-    StorageRent(StorageRentEvent),
-}
-
-#[derive(Debug)]
-pub struct Event {
-    #[allow(dead_code)] // TODO
-    chain_id: u64,
-
-    #[allow(dead_code)] // TODO
-    block_number: u64,
-
-    #[allow(dead_code)] // TODO
-    block_hash: FixedBytes<32>,
-
-    #[allow(dead_code)] // TODO
-    block_timestamp: u64,
-
-    #[allow(dead_code)] // TODO
-    log_index: u64,
-
-    #[allow(dead_code)] // TODO
-    fid: u64,
-
-    #[allow(dead_code)] // TODO
-    tx_index: u64,
-
-    #[allow(dead_code)] // TODO
-    version: u64,
-
-    #[allow(dead_code)] // TODO
-    event_type: EventType,
 }
 
 #[async_trait]
@@ -203,12 +134,22 @@ impl L1Client for RealL1Client {
 
 pub struct Subscriber {
     provider: RootProvider<Http<Client>>,
-    onchain_events_by_block: HashMap<u64, Vec<Event>>,
+    onchain_events_by_block: HashMap<u32, Vec<OnChainEvent>>,
+    shard_senders: HashMap<u32, Senders>,
+    message_router: Box<dyn MessageRouter>,
+    num_shards: u32,
+    start_block_number: u64,
+    stop_block_number: u64,
 }
 
 // TODO(aditi): Wait for 1 confirmation before "committing" an onchain event.
 impl Subscriber {
-    pub fn new(config: Config) -> Result<Subscriber, SubscribeError> {
+    pub fn new(
+        config: Config,
+        shard_senders: HashMap<u32, Senders>,
+        num_shards: u32,
+        message_router: Box<dyn MessageRouter>,
+    ) -> Result<Subscriber, SubscribeError> {
         if config.rpc_url.is_empty() {
             return Err(SubscribeError::EmptyRpcUrl);
         }
@@ -217,38 +158,85 @@ impl Subscriber {
         Ok(Subscriber {
             provider,
             onchain_events_by_block: HashMap::new(),
+            shard_senders,
+            num_shards,
+            message_router,
+            start_block_number: config.start_block_number,
+            stop_block_number: config.stop_block_number,
         })
     }
 
-    fn add_onchain_event(
+    async fn add_onchain_event(
         &mut self,
         fid: u64,
-        block_number: u64,
+        block_number: u32,
         block_hash: FixedBytes<32>,
         block_timestamp: u64,
-        log_index: u64,
-        tx_index: u64,
-        event_type: EventType,
+        log_index: u32,
+        tx_index: u32,
+        transaction_hash: FixedBytes<32>,
+        event_type: OnChainEventType,
+        event_body: on_chain_event::Body,
     ) {
-        let event = Event {
+        let event = OnChainEvent {
             fid,
             block_number,
-            block_hash,
+            block_hash: block_hash.to_vec(),
             block_timestamp,
             log_index,
             tx_index,
-            event_type,
+            r#type: event_type as i32,
             chain_id: CHAIN_ID,
             version: 0,
+            body: Some(event_body),
+            transaction_hash: transaction_hash.to_vec(),
         };
-        info!("Processed onchain event {:#?}", event);
+        info!(
+            fid,
+            event_type = event_type.as_str_name(),
+            block_number = event.block_number,
+            block_timestamp = event.block_timestamp,
+            tx_hash = hex::encode(&event.transaction_hash),
+            log_index = event.log_index,
+            "Processed onchain event"
+        );
         let events = self.onchain_events_by_block.get_mut(&block_number);
         match events {
             None => {
                 self.onchain_events_by_block
-                    .insert(block_number, vec![event]);
+                    .insert(block_number, vec![event.clone()]);
             }
-            Some(events) => events.push(event),
+            Some(events) => events.push(event.clone()),
+        }
+        let shard = self.message_router.route_message(fid, self.num_shards);
+        let senders = self.shard_senders.get(&shard);
+        match senders {
+            None => {
+                error!(
+                    block_number = event.block_number,
+                    tx_hash = hex::encode(&event.transaction_hash),
+                    log_index = event.log_index,
+                    "Unable to find shard to send onchain event to"
+                )
+            }
+            Some(senders) => {
+                if let Err(err) = senders
+                    .messages_tx
+                    .send(MempoolMessage::ValidatorMessage(ValidatorMessage {
+                        on_chain_event: Some(event.clone()),
+                        fname_transfer: None,
+                    }))
+                    .await
+                {
+                    error!(
+                        block_number = event.block_number,
+                        tx_hash = hex::encode(&event.transaction_hash),
+                        log_index = event.log_index,
+                        err = err.to_string(),
+                        "Unable to send onchain event to mempool"
+                    )
+                }
+            }
         }
     }
 
@@ -272,19 +260,25 @@ impl Subscriber {
         let tx_index = event
             .transaction_index
             .ok_or(SubscribeError::LogMissingTxIndex)?;
+        let transaction_hash = event
+            .transaction_hash
+            .ok_or(SubscribeError::LogMissingTransactionHash)?;
         // TODO(aditi): Cache these queries for timestamp to optimize rpc calls.
         // [block_timestamp] exists on [Log], however it's never populated in practice.
         let block_timestamp = self.get_block_timestamp(block_hash).await?;
-        let mut add_event = |fid, event_type| {
+        let add_event = |fid, event_type, event_body| async move {
             self.add_onchain_event(
                 fid,
-                block_number,
+                block_number as u32,
                 block_hash,
                 block_timestamp,
-                log_index,
-                tx_index,
+                log_index as u32,
+                tx_index as u32,
+                transaction_hash,
                 event_type,
-            );
+                event_body,
+            )
+            .await;
         };
         match event.topic0() {
             Some(&StorageRegistryAbi::Rent::SIGNATURE_HASH) => {
@@ -292,12 +286,14 @@ impl Subscriber {
                 let fid = Uint::to::<u64>(&fid);
                 add_event(
                     fid,
-                    EventType::StorageRent(StorageRentEvent {
-                        payer,
-                        units: Uint::to::<u64>(&units),
-                        expiry: block_timestamp + RENT_EXPIRY_IN_SECONDS,
+                    OnChainEventType::EventTypeStorageRent,
+                    on_chain_event::Body::StorageRentEventBody(StorageRentEventBody {
+                        payer: payer.to_vec(),
+                        units: Uint::to::<u32>(&units),
+                        expiry: (block_timestamp + RENT_EXPIRY_IN_SECONDS) as u32,
                     }),
-                );
+                )
+                .await;
                 Ok(())
             }
             Some(&IdRegistryAbi::Register::SIGNATURE_HASH) => {
@@ -305,11 +301,15 @@ impl Subscriber {
                 let fid = Uint::to::<u64>(&id);
                 add_event(
                     fid,
-                    EventType::IdRegister(IdRegisterEvent::Register {
-                        to,
-                        recovery_address: recovery,
+                    OnChainEventType::EventTypeIdRegister,
+                    on_chain_event::Body::IdRegisterEventBody(IdRegisterEventBody {
+                        event_type: IdRegisterEventType::Register as i32,
+                        to: to.to_vec(),
+                        recovery_address: recovery.to_vec(),
+                        from: vec![], // TODO(aditi) : What to do about this?
                     }),
-                );
+                )
+                .await;
                 Ok(())
             }
             Some(&IdRegistryAbi::Transfer::SIGNATURE_HASH) => {
@@ -317,8 +317,15 @@ impl Subscriber {
                 let fid = Uint::to::<u64>(&id);
                 add_event(
                     fid,
-                    EventType::IdRegister(IdRegisterEvent::Transfer { to, from }),
-                );
+                    OnChainEventType::EventTypeIdRegister,
+                    on_chain_event::Body::IdRegisterEventBody(IdRegisterEventBody {
+                        event_type: IdRegisterEventType::Transfer as i32,
+                        to: to.to_vec(),
+                        from: from.to_vec(),
+                        recovery_address: vec![],
+                    }),
+                )
+                .await;
                 Ok(())
             }
             Some(&IdRegistryAbi::ChangeRecoveryAddress::SIGNATURE_HASH) => {
@@ -327,10 +334,15 @@ impl Subscriber {
                 let fid = Uint::to::<u64>(&id);
                 add_event(
                     fid,
-                    EventType::IdRegister(IdRegisterEvent::ChangeRecovery {
-                        recovery_address: recovery,
+                    OnChainEventType::EventTypeIdRegister,
+                    on_chain_event::Body::IdRegisterEventBody(IdRegisterEventBody {
+                        event_type: IdRegisterEventType::ChangeRecovery as i32,
+                        to: vec![],
+                        from: vec![],
+                        recovery_address: recovery.to_vec(),
                     }),
-                );
+                )
+                .await;
                 Ok(())
             }
             Some(&KeyRegistryAbi::Add::SIGNATURE_HASH) => {
@@ -345,13 +357,16 @@ impl Subscriber {
                 let fid = Uint::to::<u64>(&fid);
                 add_event(
                     fid,
-                    EventType::Signer(SignerEvent::Add {
-                        key: keyBytes,
+                    OnChainEventType::EventTypeSigner,
+                    on_chain_event::Body::SignerEventBody(SignerEventBody {
+                        key: keyBytes.to_vec(),
                         key_type: keytype,
-                        metadata,
-                        metadata_type: metadatatype,
+                        event_type: SignerEventType::Add as i32,
+                        metadata: metadata.to_vec(),
+                        metadata_type: metadatatype as u32,
                     }),
-                );
+                )
+                .await;
                 Ok(())
             }
             Some(&KeyRegistryAbi::Remove::SIGNATURE_HASH) => {
@@ -363,8 +378,16 @@ impl Subscriber {
                 let fid = Uint::to::<u64>(&fid);
                 add_event(
                     fid,
-                    EventType::Signer(SignerEvent::Remove { key: keyBytes }),
-                );
+                    OnChainEventType::EventTypeSigner,
+                    on_chain_event::Body::SignerEventBody(SignerEventBody {
+                        key: keyBytes.to_vec(),
+                        key_type: 0,
+                        event_type: SignerEventType::Remove as i32,
+                        metadata: vec![],
+                        metadata_type: 0,
+                    }),
+                )
+                .await;
                 Ok(())
             }
             Some(&KeyRegistryAbi::AdminReset::SIGNATURE_HASH) => {
@@ -376,26 +399,49 @@ impl Subscriber {
                 let fid = Uint::to::<u64>(&fid);
                 add_event(
                     fid,
-                    EventType::Signer(SignerEvent::AdminReset { key: keyBytes }),
-                );
+                    OnChainEventType::EventTypeSigner,
+                    on_chain_event::Body::SignerEventBody(SignerEventBody {
+                        key: keyBytes.to_vec(),
+                        key_type: 0,
+                        event_type: SignerEventType::AdminReset as i32,
+                        metadata: vec![],
+                        metadata_type: 0,
+                    }),
+                )
+                .await;
                 Ok(())
             }
             Some(&KeyRegistryAbi::Migrated::SIGNATURE_HASH) => {
                 let KeyRegistryAbi::Migrated { keysMigratedAt } = event.log_decode()?.inner.data;
-                let migrated_at = Uint::to::<u64>(&keysMigratedAt);
-                add_event(0, EventType::SignerMigrated { migrated_at });
+                let migrated_at = Uint::to::<u32>(&keysMigratedAt);
+                add_event(
+                    0,
+                    OnChainEventType::EventTypeSignerMigrated,
+                    on_chain_event::Body::SignerMigratedEventBody(SignerMigratedEventBody {
+                        migrated_at,
+                    }),
+                )
+                .await;
                 Ok(())
             }
             _ => Ok(()),
         }
     }
 
-    pub async fn run(&mut self) -> Result<(), SubscribeError> {
-        // Subscribe to new events starting from now.
-        let filter = Filter::new().address(vec![STORAGE_REGISTRY, KEY_REGISTRY, ID_REGISTRY]);
-        let subscription = self.provider.watch_logs(&filter).await?;
-        let mut stream = subscription.into_stream();
-        while let Some(events) = stream.next().await {
+    pub async fn sync_historical_events(&mut self, address: Address) -> Result<(), SubscribeError> {
+        let batch_size = 1000;
+        let mut start_block = self.start_block_number;
+        loop {
+            let stop_block = self.stop_block_number.min(start_block + batch_size);
+            let filter = Filter::new()
+                .address(address)
+                .from_block(start_block)
+                .to_block(stop_block);
+            info!(
+                start_block,
+                stop_block, "Syncing historical events in range"
+            );
+            let events = self.provider.get_logs(&filter).await?;
             for event in events {
                 let result = self.process_log(&event).await;
                 match result {
@@ -406,6 +452,49 @@ impl Subscriber {
                         )
                     }
                     Ok(_) => {}
+                }
+            }
+            start_block += batch_size;
+            if start_block > self.stop_block_number {
+                info!(
+                    start_block,
+                    stop_block = self.stop_block_number,
+                    "Stopping onchain events sync"
+                );
+                return Ok(());
+            }
+        }
+    }
+
+    pub async fn run(&mut self, sync_live_events: bool) -> Result<(), SubscribeError> {
+        info!(
+            start_block_number = self.start_block_number,
+            stop_block_numer = self.stop_block_number,
+            "Starting l2 events subscription"
+        );
+        self.sync_historical_events(STORAGE_REGISTRY).await?;
+        self.sync_historical_events(ID_REGISTRY).await?;
+        self.sync_historical_events(KEY_REGISTRY).await?;
+        // TODO (aditi): [sync_live_events] should go away. We should automatically do live sync and figure out where to stop historical sync
+        if sync_live_events {
+            // Subscribe to new events starting from now.
+            let filter = Filter::new()
+                .address(vec![STORAGE_REGISTRY, KEY_REGISTRY, ID_REGISTRY])
+                .from_block(self.start_block_number);
+            let subscription = self.provider.watch_logs(&filter).await?;
+            let mut stream = subscription.into_stream();
+            while let Some(events) = stream.next().await {
+                for event in events {
+                    let result = self.process_log(&event).await;
+                    match result {
+                        Err(err) => {
+                            error!(
+                                "Error processing onchain event. Error: {:#?}. Event: {:#?}",
+                                err, event,
+                            )
+                        }
+                        Ok(_) => {}
+                    }
                 }
             }
         }


### PR DESCRIPTION
Plumb real onchain events through to the engine and have them included in blocks. 

Tested by running local snapchain nodes and observing logs and made a small parallel change to switch local nodes to `127.0.0.1` ips.